### PR TITLE
Updates to retirement pages

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -27,8 +27,8 @@ const Home: NextPage = () => {
           
           <Link href="/retirement/maximizer">
             <a className={styles.card}>
-              <h2>401k Optimizer &rarr;</h2>
-              <p>Maximize your 401k contributions</p>
+              <h2>401k Maximizer &rarr;</h2>
+              <p>Maximize your 401k contributions with equal period contributions</p>
             </a>
           </Link>
 


### PR DESCRIPTION
Changes:
- Renamed main page tile to Maximizer
- Renamed column names to be more concise or simpler(?) in retirement pages
- Maximizer
  - Moved toggles to bottom of form, added option to backload last contribution
- Frontloader
  - Added toggle to assume 401k auto caps so we can increment last contribution
  - Added ability to see add company match and see it in the table