### PR TITLE
Navbar styles and Frontload fixes

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,7 +25,7 @@ const Home: NextPage = () => {
             </a>
           </Link>
           
-          <Link href="/retirement/maximizer">
+          <Link href="/retirement/maximize">
             <a className={styles.card}>
               <h2>401k Maximizer &rarr;</h2>
               <p>Maximize your 401k contributions with equal period contributions</p>

--- a/pages/retirement/frontload.tsx
+++ b/pages/retirement/frontload.tsx
@@ -143,12 +143,14 @@ function Frontload() {
       contributionAmount = singleContributionAmount;
     }
 
-    // if 401k auto caps, we're at the last row, and contribution would not equal max,
+    // if 401k auto caps, we're at the last row, contribution would not equal max, and new contribution won't exceed max allowed
     // set contribution to max out
+    const contributionToMaxOut = _401k_maximum_contribution_individual - table_rows[i - 1][4]
     if (_401kAutoCap && 
       i == numberOfPayPeriods - 1 && 
-      contributionAmount + table_rows[i - 1][4] != _401k_maximum_contribution_individual) {
-      contributionAmount =_401k_maximum_contribution_individual - table_rows[i - 1][4];
+      contributionAmount != contributionToMaxOut &&
+      (contributionToMaxOut) / payPerPayPeriod * 100 <= maxContributionFromPaycheck) {
+      contributionAmount = contributionToMaxOut;
       contributionPercent = Math.ceil(contributionAmount / payPerPayPeriod * 100) / 100;
       _401kMaxReachedWithAutoCapAlertHTML = (
         <Alert className="mb-3" variant="secondary">
@@ -356,7 +358,7 @@ function Frontload() {
             Minimum Desired Paycheck Contribution
           </Form.Label>
           <TooltipOnHover
-            text="% of income between 0 and 100. This is effectively what you want to ensure you get a 401k match per paycheck."
+            text="% of income between 0 and 100. This is what you want to ensure you get a 401k match per paycheck."
             nest={
               <InputGroup className="mb-3 w-100">
                 <Form.Control
@@ -372,10 +374,10 @@ function Frontload() {
           />
 
           <Form.Label>
-            Maximum Paycheck Contribution Allowed
+            Maximum Paycheck Contribution
           </Form.Label>
           <TooltipOnHover
-            text="% of income between 0 and 100. You can also just put the maximum amount you are comfortable contributing."
+            text="% of income between 0 and 100. This is the maximum amount you are comfortable or are allowed to contribute."
             nest={
               <InputGroup className="mb-3 w-100">
                 <Form.Control

--- a/pages/retirement/maximize.tsx
+++ b/pages/retirement/maximize.tsx
@@ -13,7 +13,7 @@ import styles from "../../styles/Retirement.module.scss";
  * TODO's:
  * - allow user to choose between maximize and frontload
  */
-function Maximizer() {
+function Maximize() {
   const [salary, changeSalary] = React.useState(60000);
   const [_401kMaximumIndividual, change401kMaximumIndividual] = React.useState(
     _401k_maximum_contribution_individual
@@ -257,13 +257,16 @@ function Maximizer() {
 
   return (
     <div className={styles.container}>
-      <Header titleName="401k Maximizer" />
+      <Header titleName="401k Maximize" />
 
       <main className={styles.main}>
         <h1>401k Maximizer</h1>
         <p>
-          Here we will maximize your 401k contribution with equal period contributions. We will prioritize individual contributions, employer match, then anything else. 
+          Here we will maximize your 401k contribution with equal period contributions.
         </p>
+        {/* <p>
+          We will prioritize individual contributions, employer match, then anything else. 
+        </p> */}
         <p>
           We will also assume employer match cannot exceed individual contributions for any pay period.
         </p>
@@ -361,10 +364,10 @@ function Maximizer() {
           />
 
           <Form.Label>
-            Maximum Paycheck Contribution Allowed for 401k
+            Maximum Paycheck Contribution for 401k
           </Form.Label>
           <TooltipOnHover
-            text="% of income between 0 and 100. You can also just put the maximum amount you are comfortable contributing."
+            text="% of income between 0 and 100. This is the maximum amount you are comfortable or are allowed to contribute."
             nest={
               <InputGroup className="mb-3 w-100">
                 <Form.Control
@@ -402,7 +405,7 @@ function Maximizer() {
             text="You may max out contributions early and miss match. Enable this to backload contributions into last pay period."
             nest={
               <InputGroup className="mb-3 w-75">
-              <Form.Check type="checkbox" onChange={() => changeBackloadToggle(!backloadToggle)} label="Backload Contribution For Maxing out" checked={backloadToggle} />
+              <Form.Check type="checkbox" onChange={() => changeBackloadToggle(!backloadToggle)} label="Backload Contribution For Maxing Out" checked={backloadToggle} />
               </InputGroup>
             }
           />}
@@ -482,4 +485,4 @@ function Maximizer() {
   );
 }
 
-export default Maximizer;
+export default Maximize;

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -5,27 +5,47 @@ import { Container, Nav, Navbar} from 'react-bootstrap';
 /**
  * Todo:
  * - add custom styling
+ * - Be more reactive
  * - add more routing
  * 
  * Navbar items are for CSS, we have to wrap in next/link in order for single page behavior 
  * @returns NavigationBar JSX
  */
 const NavigationBar = () => {
+
+    const [isGreaterThan425px, setIsGreaterThan425px] = React.useState(false);
+
+    React.useEffect(() => {
+        function handleResize() {
+        if (window.innerWidth > 425) {
+            setIsGreaterThan425px(true);
+        } else {
+            setIsGreaterThan425px(false);
+        }
+        }
+
+        handleResize();
+
+        window.addEventListener("resize", handleResize);
+
+        return () => window.removeEventListener("resize", handleResize);
+    }, []);
+
     return (
         <Navbar bg="primary" variant="dark">
             <Container>
                 <Link href="/" passHref>
-                    <Navbar.Brand> Finance App </Navbar.Brand>
+                    <Navbar.Brand> {isGreaterThan425px ? "Finance App" : <img src="favicon.ico"/>} </Navbar.Brand>
                 </Link>
                 <Nav className="me-auto">
                     <Link href="/paycheck" passHref>
                         <Nav.Link> Paycheck </Nav.Link>
                     </Link>
-                    <Link href="/retirement/maximizer" passHref>
-                        <Nav.Link> 401k Maximizer </Nav.Link>
+                    <Link href="/retirement/maximize" passHref>
+                        <Nav.Link> {isGreaterThan425px && "401k " } Maximizer </Nav.Link>
                     </Link>
                     <Link href="/retirement/frontload" passHref>
-                        <Nav.Link> 401k Frontload </Nav.Link>
+                        <Nav.Link> {isGreaterThan425px && "401k " } Frontloader </Nav.Link>
                     </Link>
                 </Nav>
             </Container>

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -4,6 +4,7 @@ body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  overflow-x: hidden;
 }
 
 a {
@@ -56,4 +57,15 @@ $theme-colors: (
 .form-check-input:checked {
   border-color: $secondary;
   background-color: $secondary;
+}
+
+.navbar img {
+  max-width: 30px;
+  max-height: 30px;
+}
+
+@media (max-width: 425px) {
+  .navbar-brand {
+    margin: 0;
+  }
 }


### PR DESCRIPTION
Changes:
- Fixed Navbar for small screen support
  - added media query at 425px to change brand to icon and remove margin
  - removed '401k' text at < 425px
- Frontload fix
  - bug where checking auto cap will cause contribution % to exceed maximum, set another condition to stop that behavior
- Renamed maximizer to maximize to fit verbiage like frontload tool