### PR TITLE
Updates going into 2023

### DIFF
--- a/pages/retirement/frontload.tsx
+++ b/pages/retirement/frontload.tsx
@@ -18,7 +18,7 @@ import styles from "../../styles/Retirement.module.scss";
  */
 
 function Frontload() {
-  const [salary, changeSalary] = React.useState(50000);
+  const [salary, changeSalary] = React.useState(60000);
   const [_401kMaximum, change401kMaximum] = React.useState(
     _401k_maximum_contribution_individual
   );
@@ -29,11 +29,13 @@ function Frontload() {
     React.useState(0);
   // make sure to divide minContributionForMatch, maxContributionFromPaycheck, effectiveEmployerMatch by 100 to get percentage
   const [minContributionForMatch, changeMinContributionForMatch] =
-    React.useState(5);
+    React.useState(6);
   const [maxContributionFromPaycheck, changeMaxContributionFromPaycheck] =
     React.useState(90);
   const [effectiveEmployerBase, changeEffectiveEmployerBase] = React.useState(0)
-  const [effectiveEmployerMatch, changeEffectiveEmployerMatch] = React.useState(5)
+  const [effectiveEmployerMatch, changeEffectiveEmployerMatch] = React.useState(50)
+  const [effectiveEmployerMatchUpTo, changeEffectiveEmployerMatchUpTo] = React.useState(6)
+
     
   const [_401kAutoCap, change401kAutoCap] = React.useState(false);
   const [showEmployerMatchInTable, changeShowEmployerMatchInTable] = React.useState(false);
@@ -147,9 +149,9 @@ function Frontload() {
     // set contribution to max out
     if (_401kAutoCap && 
       i == numberOfPayPeriods - 1 && 
-      contributionAmount != _401k_maximum_contribution_individual - table_rows[i - 1][4] &&
-      (_401k_maximum_contribution_individual - table_rows[i - 1][4]) / payPerPayPeriod * 100 <= maxContributionFromPaycheck) {
-      contributionAmount = _401k_maximum_contribution_individual - table_rows[i - 1][4];
+      contributionAmount != _401kMaximum - table_rows[i - 1][4] &&
+      (_401kMaximum - table_rows[i - 1][4]) / payPerPayPeriod * 100 <= maxContributionFromPaycheck) {
+      contributionAmount = _401kMaximum - table_rows[i - 1][4];
       contributionPercent = Math.ceil(contributionAmount / payPerPayPeriod * 100) / 100;
       _401kMaxReachedWithAutoCapAlertHTML = (
         <Alert className="mb-3" variant="secondary">
@@ -194,7 +196,7 @@ function Frontload() {
 
     // set employer match
     let employerBaseAmount = effectiveEmployerBase * payPerPayPeriod / 100;
-    let employerMatchAmount = effectiveEmployerMatch * payPerPayPeriod / 100;
+    let employerMatchAmount = (effectiveEmployerMatch / 100 * Math.min(effectiveEmployerMatchUpTo, contributionPercent * 100)) * payPerPayPeriod / 100;
     employerAmount = employerBaseAmount + Math.min(contributionAmount, employerMatchAmount);
     cumulativeAmountTotal = i == 0 ? 
       contributionAmount + employerAmount : table_rows[i-1][6] + contributionAmount + employerAmount;
@@ -428,13 +430,14 @@ function Frontload() {
                 </InputGroup>
               }
             /> 
-            <Form.Label>
+            <Form.Label className={styles.inlineGroupFormLabel}>
               Employer 401k Match
             </Form.Label>
             <TooltipOnHover
-              text="% of income between 0 and 100. This is how much your employer contributes dependent on your contributions."
+              text="% of income between 0 and 100. This is how much your employer contributes dependent on your contributions. This is in the form of X% up to Y% of contributions."
               nest={
-                <InputGroup className="mb-3 w-100">
+                <div className={styles.inlineGroup}>
+                <InputGroup className={styles.inlineChildren}>
                   <Form.Control
                     type="number" onWheel={e => e.currentTarget.blur()}
                     value={formatStateValue(effectiveEmployerMatch)}
@@ -444,8 +447,20 @@ function Frontload() {
                   />
                   <InputGroup.Text>%</InputGroup.Text>
                 </InputGroup>
+                <p className="styles."> Up To </p>
+                <InputGroup className={styles.inlineChildren}>
+                  <Form.Control
+                    type="number" onWheel={e => e.currentTarget.blur()}
+                    value={formatStateValue(effectiveEmployerMatchUpTo)}
+                    onChange={(e) =>
+                      updateContribution(e, changeEffectiveEmployerMatchUpTo, 0, 100, true)
+                    }
+                  />
+                  <InputGroup.Text>%</InputGroup.Text>
+                </InputGroup>
+                </div>
               }
-            /> 
+            />
           </FormGroup>}
 
         </Form>

--- a/pages/retirement/maximize.tsx
+++ b/pages/retirement/maximize.tsx
@@ -36,7 +36,7 @@ function Maximize() {
   //   React.useState(5);
   const [maxContributionFromPaycheck, changeMaxContributionFromPaycheck] =
     React.useState(90);
-  const [employerMatch, changeEmployerMatch] = React.useState(5);
+  const [employerMatch, changeEmployerMatch] = React.useState(6);
 
   // Toggle
   const [megabackdoorEligible, changeMegabackdoorEligible] = React.useState(false);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,14 +12,14 @@ const Header = (props : HeaderProps) => {
     let titleSuffix = titleName ? ("| " + titleName) : "";
     let metadataContent = "Adam Lui finance " + titleName;
     return (
-        <React.Fragment>
+        <>
             <Head>
                 <title> Finance App {titleSuffix} </title>
                 <meta name="description" content={metadataContent} />
                 <link rel="icon" href={`${prefix}/favicon.ico`} />
             </Head>
             <NavigationBar/>
-        </React.Fragment>
+        </>
     );
 };
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -32,7 +32,7 @@ export enum PAY_SCHEDULE {
     WEEKLY = "Weekly",
     BIWEEKLY = "Biweekly",
     BIWEEKLY_1 = "Biweekly Offset 1",
-    BIMONTHLY = "Bimonthly",
+    SEMIMONTHLY = "Semimonthly",
     MONTHLY = "Monthly",
 }
 
@@ -40,7 +40,7 @@ export const PAY_SCHEDULE_TO_ANNUM = {
     [PAY_SCHEDULE.WEEKLY]: 52,
     [PAY_SCHEDULE.BIWEEKLY]: 26,
     [PAY_SCHEDULE.BIWEEKLY_1]: 26,
-    [PAY_SCHEDULE.BIMONTHLY]: 24,
+    [PAY_SCHEDULE.SEMIMONTHLY]: 24,
     [PAY_SCHEDULE.MONTHLY]: 12,
 }
 

--- a/src/utils/federal_withholding.ts
+++ b/src/utils/federal_withholding.ts
@@ -1,161 +1,173 @@
-// 2022
-// Source: https://www.irs.gov/pub/irs-dft/p15t--dft.pdf page 11 W4 after 2020
-// This file contains Federal withholding, SocialSecurity withholding and Medicare withholding
-import { TAX_CLASSES } from "./constants";
+/** 
+ * Latest updated year: 2023
+ * Federal Withholding Source: https://www.irs.gov/publications/p15t Manual Payroll Systems W4 after 2020
+ * Federal Withholding Source PDF: https://www.irs.gov/pub/irs-dft/p15t--dft.pdf
+ * FICA and Medicare Tax Source: https://www.nerdwallet.com/article/taxes/fica-tax-withholding
+ * Additional Medicare Tax Source https://www.irs.gov/taxtopics/tc560
+ * This file contains Federal, FICA (Social Security), and Medicare withholding
+ * We also assume only Biweekly, Semimonthly, and Monthly pay periods for Married or Single tax classes
+ */
+import { PAY_SCHEDULE, TAX_CLASSES } from "./constants";
 
 interface Withholding {
     [key: string]: number[][]
 }
 
-// Calculate (cumulative from previous tax rows) and push into rows. Array modification is by reference
-// Input withholding should be in the format [min income, max income, withholding rate]
-// Output withholding will be in the format [min income, max income, withholding rate, cumulative withholding from above rows]
-const addCumulativeColumn = (withholding_table: Withholding) => {
-    if (withholding_table[TAX_CLASSES.SINGLE][0].length > 3) return; // we must have already added the needed column
-    for (let tax_class in withholding_table) {
-        let last_sum = 0;
-        let current_sum = 0;
-        for (let row_num = 0; row_num < withholding_table[tax_class].length; row_num++) {
-            let row_ref = withholding_table[tax_class][row_num];
-            row_ref.push(last_sum + current_sum);
-            last_sum += current_sum;
-            // ignore infinity case in last row of each table
-            if (row_num != withholding_table[tax_class].length) {
-                current_sum = (row_ref[1] - row_ref[0]) * row_ref[2];
-            }
-        }
-    }
-}
-
-const raw_federal_withholding: Withholding =
-{
-    [TAX_CLASSES.SINGLE]: [
-        [0, 6275, 0.0],
-        [6275, 11250, 0.10],
-        [11250, 26538, 0.12],
-        [26538, 49463, 0.22],
-        [49463, 88738, 0.24],
-        [88738, 110988, 0.32],
-        [110988, 268075, 0.35],
-        [268075, Infinity, 0.37],
-    ],
+// Withholding will be in the format [min wage, max wage, cumulative withholding from above rows, withholding rate]
+const BIWEEKLY_WITHHOLDING: Withholding = {
     [TAX_CLASSES.MARRIED_FILING_JOINTLY]: [
-        [0, 12550, 0.0],
-        [12550, 22500, 0.10],
-        [22500, 53075, 0.12],
-        [53075, 98925, 0.22],
-        [98925, 177475, 0.24],
-        [177475, 221975, 0.32],
-        [221975, 326700, 0.35],
-        [326700, Infinity, 0.37],
+        [0, 1065, 0, 0.0],
+        [1065, 1912, 0, 0.10],
+        [1912, 4506, 84.7, 0.12],
+        [4506, 8402, 395.98, 0.22],
+        [8402, 15073, 1253.1, 0.24],
+        [15073, 18854, 2854.14, 0.32],
+        [18854, 27748, 4064.06, 0.35],
+        [27748, Infinity, 7176.96, 0.37],
     ],
-    [TAX_CLASSES.MARRIED_FILING_SEPARATELY]: [
-        [0, 6275, 0.0],
-        [6275, 11250, 0.10],
-        [11250, 26538, 0.12],
-        [26538, 49463, 0.22],
-        [49463, 88738, 0.24],
-        [88738, 110988, 0.32],
-        [110988, 268075, 0.35],
-        [268075, Infinity, 0.37],
+    [TAX_CLASSES.SINGLE]: [
+        [0, 533, 0, 0.0],
+        [533, 956, 0, 0.10],
+        [956, 2253, 42.3, 0.12],
+        [2253, 4201, 197.94, 0.22],
+        [4201, 7537, 626.50, 0.24],
+        [7537, 9427, 1427.14, 0.32],
+        [9427, 22768, 2031.94, 0.35],
+        [22768, Infinity, 6701.29, 0.37],
+    ]
+} 
+
+const SEMIMONTHLY_WITHHOLDING: Withholding = {
+    [TAX_CLASSES.MARRIED_FILING_JOINTLY]: [
+        [0, 1154, 0, 0.0],
+        [1154, 2071, 0, 0.10],
+        [2071, 4881, 91.7, 0.12],
+        [4881, 9102, 428.9, 0.22],
+        [9102, 16329, 1357.52, 0.24],
+        [16329, 20425, 3092, 0.32],
+        [20425, 30060, 4402.72, 0.35],
+        [30060, Infinity, 7774.97, 0.37],
     ],
-    [TAX_CLASSES.HEAD_OF_HOUSEHOLD]: [
-        [0, 9400, 0.0],
-        [9400, 16500, 0.10],
-        [16500, 36500, 0.12],
-        [36500, 52575, 0.22],
-        [52575, 91850, 0.24],
-        [91850, 114100, 0.32],
-        [114100, 271200, 0.35],
-        [271200, Infinity, 0.37],
+    [TAX_CLASSES.SINGLE]: [
+        [0, 577, 0, 0.0],
+        [577, 1035, 0, 0.10],
+        [1035, 2441, 45.8, 0.12],
+        [2441, 4551, 214.52, 0.22],
+        [4551, 8165, 678.72, 0.24],
+        [8165, 10213, 1546.08, 0.32],
+        [10213, 24666, 2201.44, 0.35],
+        [24666, Infinity, 7259.99, 0.37],
+    ]
+} 
+
+const MONTHLY_WITHHOLDING: Withholding = {
+    [TAX_CLASSES.MARRIED_FILING_JOINTLY]: [
+        [0, 2308, 0, 0.0],
+        [2308, 4142, 0, 0.10],
+        [4142, 9763, 183.4, 0.12],
+        [9763, 18204, 857.92, 0.22],
+        [18204, 32658, 2714.94, 0.24],
+        [32658, 40850, 6183.9, 0.32],
+        [40850, 60121, 8805.34, 0.35],
+        [60121, Infinity, 15550.19, 0.37],
     ],
-};
+    [TAX_CLASSES.SINGLE]: [
+        [0, 1154, 0, 0.0],
+        [1154, 2071, 0, 0.10],
+        [2071, 4881, 91.7, 0.12],
+        [4881, 9102, 428.9, 0.22],
+        [9102, 16329, 1357.52, 0.24],
+        [16329, 20425, 3092, 0.32],
+        [20425, 49331, 4402.72, 0.35],
+        [49331, Infinity, 14519.82, 0.37],
+    ]
+} 
 
-const processedFederalWithholding = (): Withholding => {
-    addCumulativeColumn(raw_federal_withholding);
-    return raw_federal_withholding
-}
-
-export const determineFederalTaxesWithheld = (taxableAnnualIncome: number, tax_class: TAX_CLASSES): number => {
-    let withholdingBrackets = processedFederalWithholding()[tax_class];
-    for (let row = 0; row < withholdingBrackets.length; row++) {
-        // if we're at the last bracket or the max at the current bracket is higher than income
-        if (withholdingBrackets[row][1] === Infinity || withholdingBrackets[row][1] > taxableAnnualIncome) {
-            // cumulative from previous rows + (income - min income at bracket) * tax rate at bracket
-            console.log("You're at the " + withholdingBrackets[row][2] * 100 + "% Federal withholding bracket.");
-            return withholdingBrackets[row][3] + (taxableAnnualIncome - withholdingBrackets[row][0]) * withholdingBrackets[row][2];
-        }
-    }
-    console.log("Unreachable code reached, returning 0 for federal withholding.")
-    return 0;
-};
-
-// https://www.nerdwallet.com/article/taxes/fica-tax-withholding
 // This is done individually so tax class doesn't matter.
-const raw_social_security_withholding: Withholding =
+// Income over the threshold is no longer taxed, hence we see a 0 rate.
+const FICA_WITHHOLDING: Withholding =
 {
     [TAX_CLASSES.SINGLE]: [
-        [0, 142800, 0.062],
-        [142800, Infinity, 0.0],
+        [0, 160200, 0, 0.062],
+        [160200, Infinity, 9932.4, 0.0],
     ]
 };
 
-const processedSocialSecurityWithholding = (): Withholding => {
-    addCumulativeColumn(raw_social_security_withholding);
-    return raw_social_security_withholding
-}
-
-export const determineSocialSecurityTaxesWithheld = (grossAnnualIncome: number): number => {
-    let withholdingBrackets = processedSocialSecurityWithholding()[TAX_CLASSES.SINGLE];
-    for (let row = 0; row < withholdingBrackets.length; row++) {
-        // if we're at the last bracket or the max at the current bracket is higher than income
-        if (withholdingBrackets[row][1] === Infinity || withholdingBrackets[row][1] > grossAnnualIncome) {
-            // cumulative from previous rows + (income - min income at bracket) * tax rate at bracket
-            return withholdingBrackets[row][3] + (grossAnnualIncome - withholdingBrackets[row][0]) * withholdingBrackets[row][2];
-        }
-    }
-    console.log("Unreachable code reached, returning 0 for SS withholding.")
-    return 0;
-};
-
-export const maxSocialSecurityContribution = processedSocialSecurityWithholding()[TAX_CLASSES.SINGLE][1][3];
-export const getSocialSecuritytax = raw_social_security_withholding[TAX_CLASSES.SINGLE][0][2];
-
-// Source https://www.irs.gov/taxtopics/tc560
-const raw_medicare_withholding: Withholding =
+// Married filing jointly is actually different here. 
+// Income over the threshold is an additional 0.9% so 0.0145 + 0.009 = 0.0235 for the rate above threshold
+const MEDICARE_WITHHOLDING: Withholding =
 {
     [TAX_CLASSES.SINGLE]: [
-        [0, 200000, 0.0145],
-        [200000, Infinity, 0.0235],
+        [0, 200000, 0, 0.0145],
+        [200000, Infinity, 2900, 0.0235],
     ],
     [TAX_CLASSES.MARRIED_FILING_JOINTLY]: [
-        [0, 250000, 0.0145],
-        [250000, Infinity, 0.0235],
+        [0, 250000, 0, 0.0145],
+        [250000, Infinity, 3625, 0.0235],
     ],
     [TAX_CLASSES.MARRIED_FILING_SEPARATELY]: [
-        [0, 125000, 0.0145],
-        [125000, Infinity, 0.0235],
+        [0, 125000, 0, 0.0145],
+        [125000, Infinity, 1812.5, 0.0235],
     ],
     [TAX_CLASSES.HEAD_OF_HOUSEHOLD]: [
-        [0, 200000, 0.0145],
-        [200000, Infinity, 0.0235],
+        [0, 200000, 0, 0.0145],
+        [200000, Infinity, 2900, 0.0235],
     ],
 };
 
-const processedMedicareWithholding = (): Withholding => {
-    addCumulativeColumn(raw_medicare_withholding);
-    return raw_medicare_withholding;
-}
 
-export const determineMedicareTaxesWithheld = (grossAnnualIncome: number, tax_class: TAX_CLASSES): number => {
-    let withholdingBrackets = processedMedicareWithholding()[tax_class];
-    for (let row = 0; row < withholdingBrackets.length; row++) {
-        // if we're at the last bracket or the max at the current bracket is higher than income
-        if (withholdingBrackets[row][1] === Infinity || withholdingBrackets[row][1] > grossAnnualIncome) {
-            // cumulative from previous rows + (income - min income at bracket) * tax rate at bracket
-            return withholdingBrackets[row][3] + (grossAnnualIncome - withholdingBrackets[row][0]) * withholdingBrackets[row][2];
-        }
+/**
+ * This function returns the total federal taxes to withhold from a paycheck given a wage, tax class, and pay period.
+ * TODO: Head of Household is unused in any calculators, so defaulting it to Single. 
+ * @param taxableWage 
+ * @param rawTaxClass 
+ * @param payPeriod 
+ * @returns 
+ */
+export const getFederalWithholding = (taxableWage: number, rawTaxClass: TAX_CLASSES, payPeriod: PAY_SCHEDULE): number => {
+    let taxClass = rawTaxClass;
+    if (taxClass === TAX_CLASSES.MARRIED_FILING_SEPARATELY || taxClass === TAX_CLASSES.HEAD_OF_HOUSEHOLD) {
+        taxClass = TAX_CLASSES.SINGLE;
     }
-    console.log("Unreachable code reached, returning 0 for Medicare withholding.")
-    return 0;
+    let withholdingBrackets = BIWEEKLY_WITHHOLDING[taxClass];
+    switch (payPeriod) {
+        case PAY_SCHEDULE.BIWEEKLY: 
+            break;
+        case PAY_SCHEDULE.SEMIMONTHLY:
+            withholdingBrackets = SEMIMONTHLY_WITHHOLDING[taxClass];
+        case PAY_SCHEDULE.MONTHLY:
+            withholdingBrackets = MONTHLY_WITHHOLDING[taxClass];
+        default:
+            console.log("Unsupported pay period used to call getFederalWithholding. Defaulting to biweekly.")
+            break;
+    }
+
+    let row = 0;
+    // increment row while not the last row and the max wage at current row is less than taxableWage
+    // in other words, stop when we're at the last row, or the current max wage is higher than our taxableWage
+    while (row < withholdingBrackets.length - 1 && withholdingBrackets[row][1] < taxableWage) {
+        row += 1;
+    }
+    console.log("You're at the " + withholdingBrackets[row][3] * 100 + "% Federal withholding bracket.");
+    return withholdingBrackets[row][2] + (taxableWage - withholdingBrackets[row][0]) * withholdingBrackets[row][3];
+};
+
+export const maxFICAContribution = FICA_WITHHOLDING[TAX_CLASSES.SINGLE][1][2];
+export const getFICATaxRate = FICA_WITHHOLDING[TAX_CLASSES.SINGLE][0][3];
+export const getFICAWithholding = (annualIncome: number): number => {
+    const withholdingBrackets = FICA_WITHHOLDING[TAX_CLASSES.SINGLE];
+    if (annualIncome >= withholdingBrackets[1][0]) {
+        return maxFICAContribution;
+    }
+    return annualIncome * withholdingBrackets[0][3];
+};
+
+export const getMedicareWithholding = (annualIncome: number, tax_class: TAX_CLASSES): number => {
+    const withholdingBrackets = MEDICARE_WITHHOLDING[tax_class];
+    const threshold = withholdingBrackets[1][0];
+    console.log(tax_class)
+    if (annualIncome >= threshold) {
+        return withholdingBrackets[1][2] + (annualIncome - threshold) * withholdingBrackets[1][3];
+    }
+    return annualIncome * withholdingBrackets[1][3];
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 // file that allows you to just import from /utils
-export { determineSocialSecurityTaxesWithheld, determineFederalTaxesWithheld, determineMedicareTaxesWithheld, maxSocialSecurityContribution, getSocialSecuritytax } from './federal_withholding';
+export { getFICAWithholding, getFederalWithholding, getMedicareWithholding, maxFICAContribution, getFICATaxRate} from './federal_withholding';
 export { US_STATES_MAP, instanceOfTaxUnknown, determineStateTaxesWithheld } from './state_withholding';
 export { formatCurrency, formatPercent, formatStateValue } from './helperFunctions';
 export { prefix } from './prefix';

--- a/src/utils/state_withholding.ts
+++ b/src/utils/state_withholding.ts
@@ -1,6 +1,7 @@
 /** This files contains the US States and their withholding data (if filled out)
 *   3 classes for each state: flat tax, brackets (with optional married brackets), and unknown.
-*   State taxes are hard 
+*   State taxes are hard. Some states let you choose your own withholding like AZ.
+*   TODO, add more custom state logic and major city tax toggles
 */
 import { TAX_CLASSES } from './constants';
 
@@ -52,25 +53,6 @@ interface US_STATE_MAP {
     [key: string] : US_STATE_TAX_MAP
 };
 
-// Calculate (cumulative from previous tax rows) and push into rows. Array modification is by reference
-// Input should be in the format [min income, max income, withholding rate]
-// Output will be in the format [min income, max income, withholding rate, cumulative withholding from above rows]
-// TODO: probably remove this step since it adds some complexity every time we select a state with tax brackets 
-const addCumulativeColumn = (withholding_table : number[][]) => {
-    if (withholding_table[0].length === 4) return; // we must have already added the needed column
-    let last_sum = 0;
-    let current_sum = 0;
-    for (let row_num = 0; row_num < withholding_table.length; row_num++) {
-        let row_ref = withholding_table[row_num];
-        row_ref.push(last_sum + current_sum);
-        last_sum += current_sum;
-        // ignore infinity case in last row of each table
-        if (row_num != withholding_table.length) {
-            current_sum = (row_ref[1] - row_ref[0]) * row_ref[2];
-        }
-    }
-}
-
 // main function to export
 export const determineStateTaxesWithheld = (stateAbbreviation: string, taxableAnnualIncome: number, taxClass: TAX_CLASSES): number => {
     let us_state_object = US_STATES_MAP[stateAbbreviation];
@@ -94,13 +76,12 @@ export const determineStateTaxesWithheld = (stateAbbreviation: string, taxableAn
         if (taxClass === TAX_CLASSES.MARRIED_FILING_JOINTLY && us_state_object.marriedBrackets) {
             withholdingBrackets = us_state_object.marriedBrackets; 
         }
-        addCumulativeColumn(withholdingBrackets) // add 4th column which is cumulative of taxes from rows above
         for (let row = 0; row < withholdingBrackets.length; row++) {
             // if we're at the last bracket or the max at the current bracket is higher than income
             if (withholdingBrackets[row][1] === Infinity || withholdingBrackets[row][1] > income) {
                 // cumulative from previous rows + (income - min income at bracket) * tax rate at bracket
                 console.log("You're at the " + withholdingBrackets[row][2]*100 +"% tax bracket for " + us_state_object.name + " State");
-                return withholdingBrackets[row][3] + (income - withholdingBrackets[row][0]) * withholdingBrackets[row][2];
+                return withholdingBrackets[row][2] + (income - withholdingBrackets[row][0]) * withholdingBrackets[row][3];
             }
         }
     }
@@ -110,44 +91,55 @@ export const determineStateTaxesWithheld = (stateAbbreviation: string, taxableAn
 
 // Other sources for flat tax: https://www.nerdwallet.com/article/taxes/state-income-tax-rates
 // this table is to prioritize withholdings rather than taxes
-// source: https://gist.github.com/mshafrir/2646763
+// format source: https://gist.github.com/mshafrir/2646763
 export const US_STATES_MAP : US_STATE_MAP = {
     'None': { name: 'None', abbreviation: 'None', flatTax: 0}, //adding None
-    'AL': { name: 'Alabama', abbreviation: 'AL' },
+    'AL': { 
+        name: 'Alabama', 
+        abbreviation: 'AL',
+        // source: https://smartasset.com/taxes/alabama-paycheck-calculator
+        // ignoring occupational tax rates, etc.
+        brackets: [
+            [0, 500, 0, 0.02],
+            [500, 3000, 10, 0.04],
+            [3000, Infinity, 110, 0.05]
+        ]
+    },
     'AK': { name: 'Alaska', abbreviation: 'AK', flatTax: 0 },
     'AS': { name: 'American Samoa', abbreviation: 'AS' },
-    'AZ': { name: 'Arizona', abbreviation: 'AZ' },
+    // AZ source: https://azdor.gov/businesses-arizona/withholding-tax/withholding-calculator
+    'AZ': { name: 'Arizona', abbreviation: 'AZ' }, // you get to pick your own rate on the A-4 ??
     'AR': { name: 'Arkansas', abbreviation: 'AR' },
     'CA': { 
         name: 'California', 
         abbreviation: 'CA',
-        // 2021 withholding source: https://nfc.usda.gov/Publications/HR_Payroll/Taxes/Bulletins/2021/TAXES-21-15.htm
-        // we're ignoring itemized deductions, credits, allowances, and low income exemptions...
-        standardDeduction: 4601,
-        marriedStandardDeduction: 4601,
+        // 2022 withholding source: https://www.nfc.usda.gov/Publications/HR_Payroll/Taxes/Bulletins/2022/TAXES-22-21.htm
+        // we're ignoring itemized deductions, credits, allowances, and exemptions...
+        standardDeduction: 4803,
+        marriedStandardDeduction: 4803,
         brackets: [
-            [0, 8932, 0.011],
-            [8932, 21175, 0.022],
-            [21175, 33421, 0.044],
-            [33421, 46394, 0.066],
-            [46394, 58634, 0.088],
-            [58634, 299508, 0.1023],
-            [299508, 359407, 0.1133],
-            [359407, 499012, 0.1243],
-            [499012, 1000000, 0.1353],
-            [1000000, Infinity, 0.1463],
+            [0, 9325, 0, 0.011],
+            [9325, 22107, 102.58, 0.022],
+            [22107, 34892, 383.78, 0.044],
+            [34892, 48435, 946.32, 0.066],
+            [48435, 61214, 1840.16, 0.088],
+            [61214, 312686, 2964.71, 0.1023],
+            [312686, 375221, 28690.3, 0.1133],
+            [375221, 625369, 35775.52, 0.1243],
+            [625369, 1000000, 66868.92, 0.1353],
+            [1000000, Infinity, 117556.49, 0.1463],
         ],
         marriedBrackets: [
-            [0, 17864, 0.011],
-            [17864, 42350, 0.022],
-            [42350, 66842, 0.044],
-            [66842, 92788, 0.066],
-            [92788, 117268, 0.088],
-            [117268, 599016, 0.1023],
-            [599016, 718814, 0.1133],
-            [718814, 1000000, 0.1243],
-            [1000000, 1198024, 0.1353],
-            [1198024, Infinity, 0.1463],
+            [0, 18650, 0, 0.011],
+            [18650, 44214, 205.15, 0.022],
+            [44214, 69784, 767.56, 0.044],
+            [69784, 96870, 1892.64, 0.066],
+            [96870, 122428, 3680.32, 0.088],
+            [122428, 625372, 5929.42, 0.1023],
+            [625372, 750442, 57380.59, 0.1133],
+            [750442, 1000000, 71551.02, 0.1243],
+            [1000000, 1250738, 102571.08, 0.1353],
+            [1250738, Infinity, 136495.93, 0.1463],
         ]
     },
     'CO': { name: 'Colorado', abbreviation: 'CO', flatTax: 0.0455},
@@ -158,28 +150,29 @@ export const US_STATES_MAP : US_STATE_MAP = {
         standardDeduction: 3250,
         marriedStandardDeduction: 6500,
         // 2020 data excluding exemptions: https://nfc.usda.gov/Publications/HR_Payroll/Taxes/Bulletins/2020/TAXES-20-29.htm
+        // ignoring exemptions
         brackets: [
-            [0, 2000, 0],
-            [2000, 5000, 0.022],
-            [5000, 10000, 0.039],
-            [10000, 20000, 0.048],
-            [20000, 25000, 0.052],
-            [25000, 60000, 0.0555],
-            [60000, Infinity, 0.066],
+            [0, 2000, 0, 0],
+            [2000, 5000, 0, 0.022],
+            [5000, 10000, 66, 0.039],
+            [10000, 20000, 261, 0.048],
+            [20000, 25000, 741, 0.052],
+            [25000, 60000, 1001, 0.0555],
+            [60000, Infinity, 2943.5, 0.066],
         ]
      },
     'DC': { 
         name: 'District Of Columbia', 
         abbreviation: 'DC',
-        // 2021 source https://otr.cfo.dc.gov/release/district-columbia-tax-rate-changes-effective-october-1-2021
+        // Source https://otr.cfo.dc.gov/page/dc-individual-and-fiduciary-income-tax-rates
         brackets: [
-            [0, 10000, 0.04],
-            [10000, 40000, 0.06],
-            [40000, 60000, 0.065],
-            [60000, 250000, 0.085],
-            [250000, 500000, 0.0925],
-            [500000, 1000000, 0.0975],
-            [1000000, Infinity, 0.1075],
+            [0, 10000, 0, 0.04],
+            [10000, 40000, 400, 0.06],
+            [40000, 60000, 2200, 0.065],
+            [60000, 250000, 3500, 0.085],
+            [250000, 500000, 19650, 0.0925],
+            [500000, 1000000, 42775, 0.0975],
+            [1000000, Infinity, 91525, 0.1075],
         ]    
     },
     'FM': { name: 'Federated States Of Micronesia', abbreviation: 'FM' },
@@ -202,26 +195,26 @@ export const US_STATES_MAP : US_STATE_MAP = {
         // 2021 source: https://www.marylandtaxes.gov/forms/Tax_Publications/Tax_Facts/Withholding_Tax_Facts/Withholding_Tax_Facts_2021.pdf
         // MD does not withhold under 0.0475% so we're commenting out the lower tax brackets
         brackets: [
-            // [0, 1000, 0.02],
-            // [1000, 2000, 0.03],
-            // [2000, 3000, 0.04],
-            // [3000, 100000, 0.0475],
-            [0, 100000, 0.0475],
-            [100000, 125000, 0.05],
-            [125000, 150000, 0.0525],
-            [150000, 250000, 0.055],
-            [250000, Infinity, 0.0575],
+            // [0, 1000, 0, 0.02],
+            // [1000, 2000, 20, 0.03],
+            // [2000, 3000, 50, 0.04],
+            // [3000, 100000, 90, 0.0475],
+            [0, 100000, 90, 0.0475],
+            [100000, 125000, 4697.5, 0.05],
+            [125000, 150000, 5947.5, 0.0525],
+            [150000, 250000, 7260, 0.055],
+            [250000, Infinity, 12760, 0.0575],
         ],
         marriedBrackets: [
-            // [0, 1000, 0.02],
-            // [1000, 2000, 0.03],
-            // [2000, 3000, 0.04],
-            // [3000, 150000, 0.0475],
-            [0, 150000, 0.0475],
-            [150000, 175000, 0.05],
-            [175000, 225000, 0.0525],
-            [225000, 300000, 0.055],
-            [300000, Infinity, 0.0575],
+            // [0, 1000, 0, 0.02],
+            // [1000, 2000, 20, 0.03],
+            // [2000, 3000, 50, 0.04],
+            // [3000, 150000, 90, 0.0475],
+            [0, 150000, 90, 0.0475],
+            [150000, 175000, 7072.5, 0.05],
+            [175000, 225000, 8322.5, 0.0525],
+            [225000, 300000, 10947.5, 0.055],
+            [300000, Infinity, 15072.5, 0.0575],
         ]
     },
     'MA': { name: 'Massachusetts', abbreviation: 'MA', flatTax: 0.05 },
@@ -231,17 +224,18 @@ export const US_STATES_MAP : US_STATE_MAP = {
     'MO': { 
         name: 'Missouri', 
         abbreviation: 'MO',
+        standardDeduction: 12950,
         // 2022 source https://dor.mo.gov/forms/Withholding%20Formula_2022.pdf
         brackets: [
-            [0, 1121, 0.015],
-            [1121, 2242, 0.02],
-            [2242, 3363, 0.025],
-            [3363, 4484, 0.03],
-            [4484, 5605, 0.035],
-            [5605, 6726, 0.04],
-            [6726, 7847, 0.045],
-            [7847, 8968, 0.05],
-            [8968, Infinity, 0.053],
+            [0, 1121, 0, 0.015],
+            [1121, 2242, 16.815, 0.02],
+            [2242, 3363, 39.235, 0.025],
+            [3363, 4484, 67.26, 0.03],
+            [4484, 5605, 100.89, 0.035],
+            [5605, 6726, 140.125, 0.04],
+            [6726, 7847, 184.965, 0.045],
+            [7847, 8968, 235.41, 0.05],
+            [8968, Infinity, 291.46, 0.053],
         ]
     },
     'MT': { name: 'Montana', abbreviation: 'MT' },
@@ -251,26 +245,26 @@ export const US_STATES_MAP : US_STATE_MAP = {
     'NJ': { 
         name: 'New Jersey', 
         abbreviation: 'NJ',
-        // 2021 source: https://www.forbes.com/advisor/taxes/new-jersey-state-tax/
-        // ignoring deductions and minimum income for tax
+        // 2021 source: https://www.nfc.usda.gov/Publications/HR_Payroll/Taxes/Bulletins/2021/TAXES-21-13.htm
+        // ignoring deductions, exemptions, and minimum income for tax
         brackets: [
-            [0, 20000, 0.014],
-            [20000, 35000, 0.0175],
-            [35000, 40000, 0.035],
-            [40000, 75000, 0.05525],
-            [75000, 500000, 0.0637],
-            [500000, 5000000, 0.0897],
-            [5000000, Infinity, 0.1075]
+            [0, 20000, 0, 0.015],
+            [20000, 35000, 300, 0.02],
+            [35000, 40000, 600, 0.039],
+            [40000, 75000, 795, 0.061],
+            [75000, 500000, 2930, 0.07],
+            [500000, 1000000, 32680, 0.099],
+            [1000000, Infinity, 82180, 0.118]
         ],
         marriedBrackets: [
-            [0, 20000, 0.014],
-            [20000, 50000, 0.0175],
-            [50000, 70000, 0.0245],
-            [70000, 80000, 0.035],
-            [80000, 150000, 0.05525],
-            [150000, 500000, 0.0637],
-            [500000, 5000000, 0.0897],
-            [5000000, Infinity, 0.1075]
+            [0, 20000, 0, 0.015],
+            [20000, 50000, 300, 0.02],
+            [50000, 70000, 900, 0.027],
+            [70000, 80000, 1440, 0.039],
+            [80000, 150000, 1830, 0.061],
+            [150000, 500000, 6100, 0.07],
+            [500000, 1000000, 30600, 0.099],
+            [1000000, Infinity, 80100, 0.118]
         ]
     },
     'NM': { name: 'New Mexico', abbreviation: 'NM' },
@@ -280,28 +274,28 @@ export const US_STATES_MAP : US_STATE_MAP = {
         // source: https://www.nerdwallet.com/article/taxes/new-york-state-tax
         // ignoring deductions and minimum income for tax
         brackets: [
-            [0, 8500, 0.04],
-            [8500, 11700, 0.045],
-            [11700, 13900, 0.0525],
-            [13900, 21400, 0.059],
-            [21400, 80650, 0.0597],
-            [80650, 215400, 0.0633],
-            [215400, 1077550, 0.0685],
-            [1077550, 5000000, 0.0965],
-            [5000000, 25000000, 0.103],
-            [25000000, Infinity, 0.109]
+            [0, 8500, 0, 0.04],
+            [8500, 11700, 340, 0.045],
+            [11700, 13900, 484, 0.0525],
+            [13900, 21400, 600, 0.059],
+            [21400, 80650, 1042, 0.0597],
+            [80650, 215400, 4579, 0.0633],
+            [215400, 1077550, 13109, 0.0685],
+            [1077550, 5000000, 72166, 0.0965],
+            [5000000, 25000000, 450683, 0.103],
+            [25000000, Infinity, 2510683, 0.109]
         ],
         marriedBrackets: [
-            [0, 17150, 0.04],
-            [17150, 23600, 0.045],
-            [23600, 27900, 0.0525],
-            [27900, 43000, 0.059],
-            [43000, 161550, 0.0597],
-            [161550, 323200, 0.0633],
-            [323200, 2155350, 0.0685],
-            [2155350, 5000000, 0.0965],
-            [5000000, 25000000, 0.103],
-            [25000000, Infinity, 0.109]
+            [0, 17150, 0, 0.04],
+            [17150, 23600, 686, 0.045],
+            [23600, 27900, 976, 0.0525],
+            [27900, 43000, 1202, 0.059],
+            [43000, 161550, 2093, 0.0597],
+            [161550, 323200, 9170, 0.0633],
+            [323200, 2155350, 19403, 0.0685],
+            [2155350, 5000000, 144905, 0.0965],
+            [5000000, 25000000, 419414, 0.103],
+            [25000000, Infinity, 2479414, 0.109]
         ]
     },
     'NC': { name: 'North Carolina', abbreviation: 'NC', flatTax: 0.0525 },
@@ -329,10 +323,10 @@ export const US_STATES_MAP : US_STATE_MAP = {
         standardDeduction: 4500,
         marriedStandardDeduction: 9000,
         brackets: [
-            [0, 3000, 0.02],
-            [3000, 5000, 0.03],
-            [5000, 17000, 0.05],
-            [17000, Infinity, 0.0575]
+            [0, 3000, 0, 0.02],
+            [3000, 5000, 60, 0.03],
+            [5000, 17000, 120, 0.05],
+            [17000, Infinity, 720, 0.0575]
         ] 
     },
     'WA': { name: 'Washington', abbreviation: 'WA', flatTax: 0},
@@ -342,16 +336,16 @@ export const US_STATES_MAP : US_STATE_MAP = {
         abbreviation: 'WI',
         // https://www.bankrate.com/taxes/wisconsin-state-taxes/
         brackets: [
-            [0, 11090, 0.04],
-            [11090, 22190, 0.0584],
-            [22190, 244270, 0.0627],
-            [244270, Infinity, 0.0765],
+            [0, 11090, 0, 0.04],
+            [11090, 22190, 443.6, 0.0584],
+            [22190, 244270, 1091.84, 0.0627],
+            [244270, Infinity, 15016.26, 0.0765],
         ],
         marriedBrackets: [
-            [0, 14790, 0.04],
-            [14790, 29580, 0.0584],
-            [29580, 325700, 0.0627],
-            [325700, Infinity, 0.0765],
+            [0, 14790, 0, 0.04],
+            [14790, 29580, 591.6, 0.0584],
+            [29580, 325700, 1455.34, 0.0627],
+            [325700, Infinity, 20022.06, 0.0765],
         ]
     },
     'WY': { name: 'Wyoming', abbreviation: 'WY', flatTax: 0 }

--- a/styles/Retirement.module.scss
+++ b/styles/Retirement.module.scss
@@ -76,3 +76,42 @@ $desktop: 1200px;
         justify-content: space-evenly;
     }
 }
+
+.inlineGroupFormLabel {
+    margin: 0;
+}
+
+.inlineGroup {
+    display: flex;
+    
+    @media screen and (min-width: $extraSmall) {
+        flex-direction: row;        
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+    }
+    
+    @media screen and (max-width: $extraSmall) {
+        flex-direction: column;
+    }
+}
+
+.inlineGroup p {
+    margin: 0;
+
+    @media screen and (max-width: $extraSmall) {
+        margin-top: 0.5rem;
+    }
+}
+
+.inlineChildren {
+    margin-top: 0.5rem;
+
+    @media screen and (min-width: $extraSmall) {
+        width: 35%;
+    }
+
+    @media screen and (max-width: $extraSmall) {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
Changes related to 2023:
- Updated withholding data for 2023 federal rates
- simplified head of household to single since its unused
- manually added column for cumulative values to remove redundant function calls -> perhaps using a data generator script would save manual input time
- set default salary to 60k and default match to 6%
- updated withholding function logic to remove unreachable code

Paycheck changes:
- renamed withholding functions to get_Withholding
- renamed bimonthly to semimonthly which is a more accurate term

Frontload changes:
- fixed bug when max 401k limit is changed in the form.
- added "up to" match logic and CSS