### PR TITLE
Add DCA vs Lump Sum learn page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2147,6 +2147,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2160,6 +2161,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7521,6 +7523,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -47,6 +47,12 @@ const SECTIONS: Section[] = [
         description:
           "See how long-term capital gains and qualified dividends are taxed at 0%, 15%, or 20% — and how your ordinary income affects those rates",
       },
+      {
+        href: "/learn/dca-vs-lump-sum",
+        title: "DCA vs Lump Sum",
+        description:
+          "Should you invest a windfall all at once or spread it out? Compare strategies across bull, bear, and volatile markets — uninvested cash earns HYSA interest",
+      },
     ],
   },
   {

--- a/pages/learn/dca-vs-lump-sum.tsx
+++ b/pages/learn/dca-vs-lump-sum.tsx
@@ -61,31 +61,31 @@ const SCENARIOS: {
   value: MarketScenario;
   label: string;
   icon: string;
-  description: string;
+  hint: string; // static card tooltip
 }[] = [
   {
     value: "bull",
     label: "Bull Market",
     icon: "📈",
-    description: "Steady climb — market gains momentum over time",
+    hint: "Market gains momentum — starts slow, accelerates over time",
   },
   {
     value: "bear",
     label: "Bear then Bull",
     icon: "📉",
-    description: "Market dips first, then recovers (V-shape)",
+    hint: "Market dips early then recovers (V-shape) — DCA buys cheap shares during the dip",
   },
   {
     value: "volatile",
     label: "Volatile",
     icon: "〰",
-    description: "Alternating up/down swings, same long-run return",
+    hint: "Alternating up/down months — DCA naturally buys more when prices are low",
   },
   {
     value: "flat",
     label: "Flat / Average",
     icon: "➡",
-    description: "Consistent average return every month",
+    hint: "Consistent average return every month — no path effects, only HYSA offset matters",
   },
 ];
 
@@ -97,9 +97,51 @@ const DEFAULT_INPUTS: DcaInputs = {
   dcaMonths: 12,
   marketReturnRate: 0.1,
   savingsAccountRate: 0.045,
-  scenario: "flat",
-  customMonthlyReturns: [],
+  scenario: "bear",
+  scenarioIntensity: 0.6,
 };
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function intensityLabel(i: number): string {
+  if (i < 0.25) return "Mild";
+  if (i < 0.5) return "Moderate";
+  if (i < 0.75) return "Strong";
+  return "Extreme";
+}
+
+/** Plain-English description of what the scenario is doing at a given intensity. */
+function scenarioDescription(
+  scenario: MarketScenario,
+  intensity: number,
+  marketReturnRate: number,
+): string {
+  if (scenario === "flat")
+    return "Consistent average return every month — path doesn't affect either strategy.";
+
+  const mb = Math.pow(1 + marketReturnRate, 1 / 12) - 1;
+  const I = intensity;
+
+  switch (scenario) {
+    case "bull": {
+      const startPct = Math.max(0, (1 - I) * 100).toFixed(0);
+      const endPct = ((1 + I) * 100).toFixed(0);
+      return `Market starts slow (${startPct}% of avg return) and accelerates to ${endPct}% of avg return by the end. Lump sum gets the upside from being fully invested; DCA's uninvested cash earns HYSA interest during the slow start.`;
+    }
+    case "bear": {
+      const troughAnnual = Math.pow(1 + mb * (1 - 4 * I), 12) - 1;
+      const peakAnnual = Math.pow(1 + mb * (1 + 4 * I), 12) - 1;
+      return `Market falls to ≈${formatPercent(troughAnnual)}/yr at the trough then recovers to ≈${formatPercent(peakAnnual)}/yr at the peak. DCA buys discounted shares during the dip, lowering its average cost.`;
+    }
+    case "volatile": {
+      const lowAnnual = Math.pow(1 + mb * (1 - 3 * I), 12) - 1;
+      const highAnnual = Math.pow(1 + mb * (1 + 3 * I), 12) - 1;
+      return `Returns alternate between ≈${formatPercent(lowAnnual)}/yr and ≈${formatPercent(highAnnual)}/yr each month. DCA's equal installments buy more shares on down months and fewer on up months.`;
+    }
+    default:
+      return "";
+  }
+}
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -123,6 +165,16 @@ export default function DcaVsLumpSum() {
   const winner = dcaWins ? "DCA" : "Lump Sum";
   const winnerColor = dcaWins ? DCA_COLOR : LUMP_COLOR;
 
+  const currentScenarioDesc = useMemo(
+    () =>
+      scenarioDescription(
+        inputs.scenario,
+        inputs.scenarioIntensity,
+        inputs.marketReturnRate,
+      ),
+    [inputs.scenario, inputs.scenarioIntensity, inputs.marketReturnRate],
+  );
+
   // Downsample monthly data for charts (max ~120 points)
   const chartData = useMemo(() => {
     const data = result.monthlyData;
@@ -131,7 +183,7 @@ export default function DcaVsLumpSum() {
     return data.filter((_, i) => i % step === 0 || i === data.length - 1);
   }, [result.monthlyData]);
 
-  // Price path data (normalised to 100)
+  // Price path data (normalised to 100 at month 0)
   const pricePath = useMemo(() => {
     let price = 100;
     return result.monthlyReturns.slice(0, horizonMonths).map((r, i) => {
@@ -140,7 +192,6 @@ export default function DcaVsLumpSum() {
     });
   }, [result.monthlyReturns, horizonMonths]);
 
-  // Final value bar chart data
   const barData = [
     { name: "DCA", value: result.finalDcaTotal, fill: DCA_COLOR },
     { name: "Lump Sum", value: result.finalLumpSum, fill: LUMP_COLOR },
@@ -156,8 +207,8 @@ export default function DcaVsLumpSum() {
           You have a windfall or savings ready to invest. Should you put it all
           in at once (<strong>lump sum</strong>), or spread it out over time (
           <strong>dollar-cost averaging</strong>)? Money not yet invested earns
-          interest in a savings account. Tune the market scenario and see which
-          strategy comes out ahead.
+          interest in a savings account. Tune the scenario and intensity to see
+          which strategy comes out ahead.
         </p>
       </main>
 
@@ -300,16 +351,12 @@ export default function DcaVsLumpSum() {
 
           {/* ── Market Scenario ── */}
           <p className={shared.sectionLabel}>Market Scenario</p>
-          <p className={shared.rateHint}>
-            Choose how the market behaves during your investment period. All
-            scenarios share the same long-run annual return above.
-          </p>
 
           <div className={styles.scenarioGrid}>
             {SCENARIOS.map((s) => (
               <div key={s.value}>
                 <TooltipOnHover
-                  text={s.description}
+                  text={s.hint}
                   nest={
                     <div
                       className={
@@ -333,6 +380,40 @@ export default function DcaVsLumpSum() {
               </div>
             ))}
           </div>
+
+          {/* Intensity slider — hidden for flat */}
+          {inputs.scenario !== "flat" && (
+            <>
+              <div className={styles.dcaSlider} style={{ marginTop: "1rem" }}>
+                <div className={styles.dcaMonthDisplay}>
+                  <Form.Label className="mb-0">Scenario Intensity</Form.Label>
+                  <span
+                    className={styles.dcaMonthBadge}
+                    style={{ color: "#e67e22" }}
+                  >
+                    {intensityLabel(inputs.scenarioIntensity)}
+                  </span>
+                </div>
+                <Form.Range
+                  min={5}
+                  max={100}
+                  step={5}
+                  value={Math.round(inputs.scenarioIntensity * 100)}
+                  onChange={(e) =>
+                    setField(
+                      "scenarioIntensity",
+                      parseInt(e.target.value) / 100,
+                    )
+                  }
+                />
+                <div className="d-flex justify-content-between">
+                  <small className="text-muted">Mild</small>
+                  <small className="text-muted">Extreme</small>
+                </div>
+              </div>
+              <p className={shared.rateHint}>{currentScenarioDesc}</p>
+            </>
+          )}
         </Form>
 
         {/* ── RESULTS ──────────────────────────────────────────────────────── */}
@@ -340,7 +421,7 @@ export default function DcaVsLumpSum() {
           {/* Key insight alert */}
           <Alert
             variant={dcaWins ? "info" : "primary"}
-            className="mb-3"
+            className="mb-2"
             style={{ borderLeft: `4px solid ${winnerColor}` }}
           >
             <strong style={{ color: winnerColor }}>{winner} wins</strong> in
@@ -351,8 +432,8 @@ export default function DcaVsLumpSum() {
                 <strong>
                   {formatCurrency(Math.abs(result.dcaVsLumpSumDiff))}
                 </strong>{" "}
-                ahead. The HYSA interest on uninvested cash and lower average
-                buy price more than compensate for time out of market.
+                ahead. Lower average buy price and HYSA interest on idle cash
+                outweigh missing time in market.
               </>
             ) : (
               <>
@@ -360,11 +441,21 @@ export default function DcaVsLumpSum() {
                 <strong>
                   {formatCurrency(Math.abs(result.dcaVsLumpSumDiff))}
                 </strong>{" "}
-                ahead. Getting fully invested immediately lets compounding work
-                on the full amount sooner.
+                ahead. Full compounding from day one beats the benefit of
+                spreading purchases.
               </>
             )}
           </Alert>
+
+          {/* Why are the differences small? */}
+          <p className={shared.chartNote} style={{ marginBottom: "1rem" }}>
+            <strong>Why are the differences often small?</strong> That&apos;s
+            realistic. Research shows lump sum beats DCA ≈65% of the time in
+            rising equity markets, but typically by only 2–4% over a 12-month
+            DCA window. The gap widens with a longer DCA period, higher market
+            volatility, and deeper drawdowns — use the intensity slider to
+            explore extremes.
+          </p>
 
           {/* Summary cards */}
           <div className={shared.summaryCards}>
@@ -527,9 +618,9 @@ export default function DcaVsLumpSum() {
                 </LineChart>
               </ResponsiveContainer>
               <p className={shared.chartNote}>
-                The dashed gray line shows cash still sitting in the HYSA
-                waiting to be deployed. Once DCA is complete at month{" "}
-                {inputs.dcaMonths}, both strategies are fully invested.
+                The dashed gray line shows cash still in the HYSA waiting to be
+                deployed. After month {inputs.dcaMonths} both strategies are
+                fully invested and move in lockstep.
               </p>
             </div>
           )}
@@ -540,7 +631,7 @@ export default function DcaVsLumpSum() {
               <h5 className="text-center mb-3">
                 Final Portfolio Value at {inputs.investmentHorizonYears} Years
               </h5>
-              <ResponsiveContainer width="100%" height={300}>
+              <ResponsiveContainer width="100%" height={280}>
                 <BarChart
                   data={barData}
                   margin={{ top: 10, right: 20, left: 10, bottom: 10 }}
@@ -622,8 +713,8 @@ export default function DcaVsLumpSum() {
 
               <p className={shared.chartNote}>
                 {result.avgCostAdvantage > 0
-                  ? `DCA achieved a lower average buy price (${result.averageBuyPrice.toFixed(1)} vs ${result.lumpSumBuyPrice.toFixed(1)}), but time out of market cost some compounding.`
-                  : `Lump sum secured a lower entry price. In a rising market, buying earlier is typically better.`}
+                  ? `DCA achieved a lower average buy price (${result.averageBuyPrice.toFixed(1)} vs ${result.lumpSumBuyPrice.toFixed(1)}), but time out of market reduces total compounding.`
+                  : `Lump sum secured a lower entry price — in a rising market, buying earlier is typically better.`}
               </p>
             </div>
           )}
@@ -633,6 +724,12 @@ export default function DcaVsLumpSum() {
             <div className={shared.chartWrap}>
               <h5 className="text-center mb-3">
                 Market Price Path — {result.scenarioLabel}
+                {inputs.scenario !== "flat" && (
+                  <span className="text-muted fs-6">
+                    {" "}
+                    ({intensityLabel(inputs.scenarioIntensity)} intensity)
+                  </span>
+                )}
               </h5>
               <ResponsiveContainer width="100%" height={320}>
                 <LineChart
@@ -670,7 +767,7 @@ export default function DcaVsLumpSum() {
                     stroke="#888"
                     strokeDasharray="4 3"
                     label={{
-                      value: "Start",
+                      value: "Start (100)",
                       position: "insideTopLeft",
                       fontSize: 11,
                     }}
@@ -699,10 +796,11 @@ export default function DcaVsLumpSum() {
                 </LineChart>
               </ResponsiveContainer>
               <p className={shared.chartNote}>
-                All scenarios produce the same long-run annualised return (
-                {formatPercent(inputs.marketReturnRate)}), but the path affects
-                how much each strategy benefits from timing. DCA buys more
-                shares when prices are low and fewer when high.
+                All scenarios share the same long-run annualised return (
+                {formatPercent(inputs.marketReturnRate)}), but the path shape
+                determines how much the DCA strategy benefits from buying at
+                different prices along the way. Use the intensity slider to make
+                the path more or less extreme.
               </p>
             </div>
           )}

--- a/pages/learn/dca-vs-lump-sum.tsx
+++ b/pages/learn/dca-vs-lump-sum.tsx
@@ -1,0 +1,709 @@
+import { useState, useMemo } from "react";
+import {
+  Alert,
+  Form,
+  InputGroup,
+  ToggleButton,
+  ToggleButtonGroup,
+} from "react-bootstrap";
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ReferenceLine,
+  ResponsiveContainer,
+} from "recharts";
+import { Header, Footer, TooltipOnHover } from "../../src/components";
+import { useChartTooltipProps } from "../../src/utils/ThemeContext";
+import { formatCurrency, formatPercent, formatStateValue } from "../../src/utils";
+import {
+  calcDcaVsLumpSum,
+  type DcaInputs,
+  type MarketScenario,
+} from "../../src/utils/dca_vs_lumpsum_utils";
+import retirementStyles from "../../styles/Retirement.module.scss";
+import shared from "../../styles/shared.module.scss";
+import styles from "../../styles/DcaVsLumpSum.module.scss";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DCA_COLOR = "#2980b9";
+const LUMP_COLOR = "#8e44ad";
+const CASH_COLOR = "#95a5a6";
+
+const formatChartDollar = (v: number) =>
+  v >= 1_000_000
+    ? `$${(v / 1_000_000).toFixed(1)}M`
+    : v >= 1_000
+      ? `$${(v / 1_000).toFixed(0)}k`
+      : `$${v.toFixed(0)}`;
+
+const formatMonth = (m: number) =>
+  m >= 24 ? `${Math.round(m / 12)}yr` : `${m}mo`;
+
+type ChartView = "growth" | "breakdown" | "pricepath";
+
+// ─── Scenario definitions ─────────────────────────────────────────────────────
+
+const SCENARIOS: {
+  value: MarketScenario;
+  label: string;
+  icon: string;
+  description: string;
+}[] = [
+  {
+    value: "bull",
+    label: "Bull Market",
+    icon: "📈",
+    description: "Steady climb — market gains momentum over time",
+  },
+  {
+    value: "bear",
+    label: "Bear then Bull",
+    icon: "📉",
+    description: "Market dips first, then recovers (V-shape)",
+  },
+  {
+    value: "volatile",
+    label: "Volatile",
+    icon: "〰",
+    description: "Alternating up/down swings, same long-run return",
+  },
+  {
+    value: "flat",
+    label: "Flat / Average",
+    icon: "➡",
+    description: "Consistent average return every month",
+  },
+];
+
+// ─── Default inputs ────────────────────────────────────────────────────────────
+
+const DEFAULT_INPUTS: DcaInputs = {
+  totalAmount: 50000,
+  investmentHorizonYears: 10,
+  dcaMonths: 12,
+  marketReturnRate: 0.1,
+  savingsAccountRate: 0.045,
+  scenario: "flat",
+  customMonthlyReturns: [],
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function DcaVsLumpSum() {
+  const { contentStyle: tooltipStyle, labelStyle: tooltipLabelStyle } =
+    useChartTooltipProps();
+
+  const [inputs, setInputs] = useState<DcaInputs>(DEFAULT_INPUTS);
+  const [chartView, setChartView] = useState<ChartView>("growth");
+
+  const setField = <K extends keyof DcaInputs>(key: K, value: DcaInputs[K]) =>
+    setInputs((prev) => ({ ...prev, [key]: value }));
+
+  const clamp = (v: number, min: number, max: number) =>
+    isNaN(v) ? min : Math.min(max, Math.max(min, v));
+
+  const result = useMemo(() => calcDcaVsLumpSum(inputs), [inputs]);
+
+  const horizonMonths = inputs.investmentHorizonYears * 12;
+  const dcaWins = result.dcaWins;
+  const winner = dcaWins ? "DCA" : "Lump Sum";
+  const winnerColor = dcaWins ? DCA_COLOR : LUMP_COLOR;
+
+  // Downsample monthly data for charts (max ~120 points)
+  const chartData = useMemo(() => {
+    const data = result.monthlyData;
+    if (data.length <= 120) return data;
+    const step = Math.ceil(data.length / 120);
+    return data.filter((_, i) => i % step === 0 || i === data.length - 1);
+  }, [result.monthlyData]);
+
+  // Price path data (normalised to 100)
+  const pricePath = useMemo(() => {
+    let price = 100;
+    return result.monthlyReturns
+      .slice(0, horizonMonths)
+      .map((r, i) => {
+        price = price * (1 + r);
+        return { month: i + 1, price };
+      });
+  }, [result.monthlyReturns, horizonMonths]);
+
+  // Final value bar chart data
+  const barData = [
+    { name: "DCA", value: result.finalDcaTotal, fill: DCA_COLOR },
+    { name: "Lump Sum", value: result.finalLumpSum, fill: LUMP_COLOR },
+  ];
+
+  return (
+    <div className={retirementStyles.container}>
+      <Header titleName="DCA vs Lump Sum" />
+
+      <main className={retirementStyles.main}>
+        <h1>Dollar-Cost Averaging vs Lump Sum</h1>
+        <p>
+          You have a windfall or savings ready to invest. Should you put it all
+          in at once (<strong>lump sum</strong>), or spread it out over time (
+          <strong>dollar-cost averaging</strong>)? Money not yet invested earns
+          interest in a savings account. Tune the market scenario and see which
+          strategy comes out ahead.
+        </p>
+      </main>
+
+      <div className={retirementStyles.content}>
+        {/* ── FORM ─────────────────────────────────────────────────────────── */}
+        <Form className={retirementStyles.form}>
+          {/* ── Money Available ── */}
+          <p className={shared.sectionLabel}>Your Money</p>
+
+          <Form.Label>Total Amount to Invest</Form.Label>
+          <TooltipOnHover
+            text="The total lump sum you have available to invest, e.g. a bonus, inheritance, or accumulated savings."
+            nest={
+              <InputGroup className="mb-3 w-100">
+                <InputGroup.Text>$</InputGroup.Text>
+                <Form.Control
+                  type="number"
+                  onWheel={(e) => e.currentTarget.blur()}
+                  value={formatStateValue(inputs.totalAmount)}
+                  onChange={(e) =>
+                    setField(
+                      "totalAmount",
+                      clamp(parseFloat(e.target.value), 1, 100_000_000),
+                    )
+                  }
+                />
+              </InputGroup>
+            }
+          />
+
+          <Form.Label>Investment Horizon</Form.Label>
+          <TooltipOnHover
+            text="How many years you plan to stay invested. The final portfolio value is measured at this point."
+            nest={
+              <InputGroup className="mb-3 w-100">
+                <Form.Control
+                  type="number"
+                  onWheel={(e) => e.currentTarget.blur()}
+                  value={formatStateValue(inputs.investmentHorizonYears)}
+                  onChange={(e) =>
+                    setField(
+                      "investmentHorizonYears",
+                      clamp(parseFloat(e.target.value), 1, 40),
+                    )
+                  }
+                />
+                <InputGroup.Text>years</InputGroup.Text>
+              </InputGroup>
+            }
+          />
+
+          {/* ── DCA Schedule ── */}
+          <p className={shared.sectionLabel}>DCA Schedule</p>
+
+          <div className={styles.dcaSlider}>
+            <div className={styles.dcaMonthDisplay}>
+              <Form.Label className="mb-0">Spread investments over</Form.Label>
+              <span className={styles.dcaMonthBadge} style={{ color: DCA_COLOR }}>
+                {inputs.dcaMonths}
+              </span>
+              <Form.Label className="mb-0">months</Form.Label>
+            </div>
+            <Form.Range
+              min={1}
+              max={Math.min(inputs.investmentHorizonYears * 12, 60)}
+              value={inputs.dcaMonths}
+              onChange={(e) => setField("dcaMonths", parseInt(e.target.value))}
+            />
+            <div className="d-flex justify-content-between">
+              <small className="text-muted">1 mo (= lump sum)</small>
+              <small className="text-muted">
+                {Math.min(inputs.investmentHorizonYears * 12, 60)} mo
+              </small>
+            </div>
+          </div>
+
+          <p className={shared.rateHint}>
+            Monthly installment:{" "}
+            <strong>{formatCurrency(result.monthlyInstallment)}</strong> — cash
+            not yet invested earns {formatPercent(inputs.savingsAccountRate)}{" "}
+            in a HYSA
+          </p>
+
+          {/* ── Return Assumptions ── */}
+          <p className={shared.sectionLabel}>Return Assumptions</p>
+
+          <div className={shared.twoCol}>
+            <div className={shared.col}>
+              <Form.Label>Market Return</Form.Label>
+              <TooltipOnHover
+                text="Expected average annual return for the invested portfolio (e.g. a broad index fund). The S&P 500 has averaged ~10% annually over the long run."
+                nest={
+                  <InputGroup className="mb-3 w-100">
+                    <Form.Control
+                      type="number"
+                      onWheel={(e) => e.currentTarget.blur()}
+                      value={formatStateValue(
+                        Math.round(inputs.marketReturnRate * 10000) / 100,
+                      )}
+                      onChange={(e) =>
+                        setField(
+                          "marketReturnRate",
+                          clamp(parseFloat(e.target.value), 0, 50) / 100,
+                        )
+                      }
+                    />
+                    <InputGroup.Text>%</InputGroup.Text>
+                  </InputGroup>
+                }
+              />
+            </div>
+            <div className={shared.col}>
+              <Form.Label>Savings / HYSA Rate</Form.Label>
+              <TooltipOnHover
+                text="Annual interest rate for cash sitting in a high-yield savings account while waiting to be invested (DCA only)."
+                nest={
+                  <InputGroup className="mb-3 w-100">
+                    <Form.Control
+                      type="number"
+                      onWheel={(e) => e.currentTarget.blur()}
+                      value={formatStateValue(
+                        Math.round(inputs.savingsAccountRate * 10000) / 100,
+                      )}
+                      onChange={(e) =>
+                        setField(
+                          "savingsAccountRate",
+                          clamp(parseFloat(e.target.value), 0, 20) / 100,
+                        )
+                      }
+                    />
+                    <InputGroup.Text>%</InputGroup.Text>
+                  </InputGroup>
+                }
+              />
+            </div>
+          </div>
+
+          {/* ── Market Scenario ── */}
+          <p className={shared.sectionLabel}>Market Scenario</p>
+          <p className={shared.rateHint}>
+            Choose how the market behaves during your investment period. All
+            scenarios share the same long-run annual return above.
+          </p>
+
+          <div className={styles.scenarioGrid}>
+            {SCENARIOS.map((s) => (
+              <div key={s.value}>
+              <TooltipOnHover
+                text={s.description}
+                nest={
+                  <div
+                    className={
+                      inputs.scenario === s.value
+                        ? styles.scenarioCardActive
+                        : styles.scenarioCard
+                    }
+                    onClick={() => setField("scenario", s.value)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ")
+                        setField("scenario", s.value);
+                    }}
+                  >
+                    <div className={styles.scenarioIcon}>{s.icon}</div>
+                    <div>{s.label}</div>
+                  </div>
+                }
+              />
+              </div>
+            ))}
+          </div>
+        </Form>
+
+        {/* ── RESULTS ──────────────────────────────────────────────────────── */}
+        <div className={shared.results}>
+          {/* Key insight alert */}
+          <Alert
+            variant={dcaWins ? "info" : "primary"}
+            className="mb-3"
+            style={{ borderLeft: `4px solid ${winnerColor}` }}
+          >
+            <strong style={{ color: winnerColor }}>{winner} wins</strong> in
+            this scenario —{" "}
+            {dcaWins ? (
+              <>
+                DCA ends up{" "}
+                <strong>{formatCurrency(Math.abs(result.dcaVsLumpSumDiff))}</strong>{" "}
+                ahead. The HYSA interest on uninvested cash and lower average
+                buy price more than compensate for time out of market.
+              </>
+            ) : (
+              <>
+                Lump Sum ends up{" "}
+                <strong>{formatCurrency(Math.abs(result.dcaVsLumpSumDiff))}</strong>{" "}
+                ahead. Getting fully invested immediately lets compounding work
+                on the full amount sooner.
+              </>
+            )}
+          </Alert>
+
+          {/* Summary cards */}
+          <div className={shared.summaryCards}>
+            <div className={shared.card}>
+              <div className={shared.cardLabel}>DCA Final Value</div>
+              <div className={shared.cardValue} style={{ color: DCA_COLOR }}>
+                {formatCurrency(result.finalDcaTotal)}
+              </div>
+              <div className={shared.cardSub}>
+                over {inputs.dcaMonths} months at{" "}
+                {formatCurrency(result.monthlyInstallment)}/mo
+              </div>
+            </div>
+            <div className={shared.card}>
+              <div className={shared.cardLabel}>Lump Sum Final Value</div>
+              <div className={shared.cardValue} style={{ color: LUMP_COLOR }}>
+                {formatCurrency(result.finalLumpSum)}
+              </div>
+              <div className={shared.cardSub}>invested all at once</div>
+            </div>
+            <div className={shared.card}>
+              <div className={shared.cardLabel}>
+                {dcaWins ? "DCA Advantage" : "Lump Sum Advantage"}
+              </div>
+              <div
+                className={shared.cardValue}
+                style={{ color: winnerColor }}
+              >
+                {formatCurrency(Math.abs(result.dcaVsLumpSumDiff))}
+              </div>
+              <div className={shared.cardSub}>
+                {formatPercent(
+                  Math.abs(result.dcaVsLumpSumDiff) / result.totalContributed,
+                )}{" "}
+                of total invested
+              </div>
+            </div>
+            <div className={shared.card}>
+              <div className={shared.cardLabel}>DCA Avg Buy Price</div>
+              <div
+                className={shared.cardValue}
+                style={{
+                  color: result.avgCostAdvantage > 0 ? DCA_COLOR : LUMP_COLOR,
+                }}
+              >
+                {result.averageBuyPrice.toFixed(1)}
+              </div>
+              <div className={shared.cardSub}>
+                vs {result.lumpSumBuyPrice.toFixed(1)} for lump sum (index
+                starts at 100)
+              </div>
+            </div>
+          </div>
+
+          {/* Chart toggle */}
+          <div className={shared.chartToggle}>
+            <ToggleButtonGroup
+              type="radio"
+              name="chartView"
+              value={chartView}
+              onChange={(v: ChartView) => setChartView(v)}
+            >
+              <ToggleButton
+                id="view-growth"
+                value="growth"
+                variant="outline-primary"
+              >
+                Portfolio Growth
+              </ToggleButton>
+              <ToggleButton
+                id="view-breakdown"
+                value="breakdown"
+                variant="outline-primary"
+              >
+                Final Comparison
+              </ToggleButton>
+              <ToggleButton
+                id="view-pricepath"
+                value="pricepath"
+                variant="outline-primary"
+              >
+                Market Path
+              </ToggleButton>
+            </ToggleButtonGroup>
+          </div>
+
+          {/* Chart 1 — Portfolio Growth Over Time */}
+          {chartView === "growth" && (
+            <div className={shared.chartWrap}>
+              <h5 className="text-center mb-1">Portfolio Value Over Time</h5>
+              <p className="text-center text-muted mb-3" style={{ fontSize: "0.82rem" }}>
+                DCA total includes cash still in HYSA
+              </p>
+              <ResponsiveContainer width="100%" height={380}>
+                <LineChart
+                  data={chartData}
+                  margin={{ top: 10, right: 20, left: 10, bottom: 24 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                  <XAxis
+                    dataKey="month"
+                    tickFormatter={formatMonth}
+                    label={{
+                      value: "Time",
+                      position: "insideBottom",
+                      offset: -12,
+                    }}
+                  />
+                  <YAxis tickFormatter={formatChartDollar} width={65} />
+                  <Tooltip
+                    formatter={(value: number | undefined, name: string | undefined) => [
+                      formatCurrency(value ?? 0),
+                      name ?? "",
+                    ]}
+                    labelFormatter={(m) => `Month ${m} (${formatMonth(m as number)})`}
+                    contentStyle={tooltipStyle}
+                    labelStyle={tooltipLabelStyle}
+                  />
+                  <Legend verticalAlign="top" />
+                  {inputs.dcaMonths > 1 && (
+                    <ReferenceLine
+                      x={inputs.dcaMonths}
+                      stroke={DCA_COLOR}
+                      strokeDasharray="4 3"
+                      label={{
+                        value: "DCA complete",
+                        position: "insideTopRight",
+                        fontSize: 11,
+                        fill: DCA_COLOR,
+                      }}
+                    />
+                  )}
+                  <Line
+                    type="monotone"
+                    dataKey="dcaTotal"
+                    name="DCA (invested + HYSA cash)"
+                    stroke={DCA_COLOR}
+                    strokeWidth={2}
+                    dot={false}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="lumpSumPortfolio"
+                    name="Lump Sum"
+                    stroke={LUMP_COLOR}
+                    strokeWidth={2}
+                    dot={false}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="dcaCash"
+                    name="DCA uninvested cash (HYSA)"
+                    stroke={CASH_COLOR}
+                    strokeWidth={1.5}
+                    strokeDasharray="5 3"
+                    dot={false}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+              <p className={shared.chartNote}>
+                The dashed gray line shows cash still sitting in the HYSA
+                waiting to be deployed. Once DCA is complete at month{" "}
+                {inputs.dcaMonths}, both strategies are fully invested.
+              </p>
+            </div>
+          )}
+
+          {/* Chart 2 — Final Value Comparison */}
+          {chartView === "breakdown" && (
+            <div className={shared.chartWrap}>
+              <h5 className="text-center mb-3">
+                Final Portfolio Value at {inputs.investmentHorizonYears} Years
+              </h5>
+              <ResponsiveContainer width="100%" height={300}>
+                <BarChart
+                  data={barData}
+                  margin={{ top: 10, right: 20, left: 10, bottom: 10 }}
+                  barCategoryGap="35%"
+                >
+                  <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                  <XAxis dataKey="name" />
+                  <YAxis tickFormatter={formatChartDollar} width={65} />
+                  <Tooltip
+                    formatter={(value: number | undefined, name: string | undefined) => [
+                      formatCurrency(value ?? 0),
+                      name ?? "",
+                    ]}
+                    contentStyle={tooltipStyle}
+                    labelStyle={tooltipLabelStyle}
+                  />
+                  <Bar
+                    dataKey="value"
+                    name="Final Value"
+                    isAnimationActive={false}
+                    shape={(props: Record<string, unknown>) => {
+                      const { x, y, width, height, index } = props as {
+                        x: number;
+                        y: number;
+                        width: number;
+                        height: number;
+                        index: number;
+                      };
+                      return (
+                        <rect
+                          x={x}
+                          y={y}
+                          width={width}
+                          height={height}
+                          fill={barData[index]?.fill ?? "#888"}
+                          opacity={0.85}
+                          rx={4}
+                          ry={4}
+                        />
+                      );
+                    }}
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+
+              {/* Breakdown table */}
+              <div className="mt-3">
+                <table className="table table-sm table-bordered text-center mb-0">
+                  <thead>
+                    <tr>
+                      <th></th>
+                      <th style={{ color: DCA_COLOR }}>DCA</th>
+                      <th style={{ color: LUMP_COLOR }}>Lump Sum</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Total Invested</td>
+                      <td>{formatCurrency(result.totalContributed)}</td>
+                      <td>{formatCurrency(result.totalContributed)}</td>
+                    </tr>
+                    <tr>
+                      <td>Final Portfolio</td>
+                      <td style={{ color: DCA_COLOR, fontWeight: 600 }}>
+                        {formatCurrency(result.finalDcaTotal)}
+                      </td>
+                      <td style={{ color: LUMP_COLOR, fontWeight: 600 }}>
+                        {formatCurrency(result.finalLumpSum)}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Gain</td>
+                      <td>
+                        {formatCurrency(
+                          result.finalDcaTotal - result.totalContributed,
+                        )}
+                      </td>
+                      <td>
+                        {formatCurrency(
+                          result.finalLumpSum - result.totalContributed,
+                        )}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Avg Buy Price (index)</td>
+                      <td>{result.averageBuyPrice.toFixed(2)}</td>
+                      <td>{result.lumpSumBuyPrice.toFixed(2)}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <p className={shared.chartNote}>
+                {result.avgCostAdvantage > 0
+                  ? `DCA achieved a lower average buy price (${result.averageBuyPrice.toFixed(1)} vs ${result.lumpSumBuyPrice.toFixed(1)}), but time out of market cost some compounding.`
+                  : `Lump sum secured a lower entry price. In a rising market, buying earlier is typically better.`}
+              </p>
+            </div>
+          )}
+
+          {/* Chart 3 — Market Price Path */}
+          {chartView === "pricepath" && (
+            <div className={shared.chartWrap}>
+              <h5 className="text-center mb-3">
+                Market Price Path — {result.scenarioLabel}
+              </h5>
+              <ResponsiveContainer width="100%" height={320}>
+                <LineChart
+                  data={pricePath}
+                  margin={{ top: 10, right: 20, left: 10, bottom: 24 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                  <XAxis
+                    dataKey="month"
+                    tickFormatter={formatMonth}
+                    label={{
+                      value: "Time",
+                      position: "insideBottom",
+                      offset: -12,
+                    }}
+                  />
+                  <YAxis
+                    domain={["auto", "auto"]}
+                    tickFormatter={(v) => v.toFixed(0)}
+                    width={55}
+                  />
+                  <Tooltip
+                    formatter={(v: number | undefined) => [
+                      (v ?? 0).toFixed(1),
+                      "Price index",
+                    ]}
+                    labelFormatter={(m) => `Month ${m} (${formatMonth(m as number)})`}
+                    contentStyle={tooltipStyle}
+                    labelStyle={tooltipLabelStyle}
+                  />
+                  <ReferenceLine
+                    y={100}
+                    stroke="#888"
+                    strokeDasharray="4 3"
+                    label={{ value: "Start", position: "insideTopLeft", fontSize: 11 }}
+                  />
+                  {inputs.dcaMonths > 1 && (
+                    <ReferenceLine
+                      x={inputs.dcaMonths}
+                      stroke={DCA_COLOR}
+                      strokeDasharray="4 3"
+                      label={{
+                        value: "DCA done",
+                        position: "insideTopRight",
+                        fontSize: 11,
+                        fill: DCA_COLOR,
+                      }}
+                    />
+                  )}
+                  <Line
+                    type="monotone"
+                    dataKey="price"
+                    name="Market Index"
+                    stroke="#e67e22"
+                    strokeWidth={2}
+                    dot={false}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+              <p className={shared.chartNote}>
+                All scenarios produce the same long-run annualised return (
+                {formatPercent(inputs.marketReturnRate)}), but the path affects
+                how much each strategy benefits from timing. DCA buys more
+                shares when prices are low and fewer when high.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Footer />
+    </div>
+  );
+}

--- a/pages/learn/dca-vs-lump-sum.tsx
+++ b/pages/learn/dca-vs-lump-sum.tsx
@@ -17,11 +17,17 @@ import {
   Tooltip,
   Legend,
   ReferenceLine,
+  Rectangle,
   ResponsiveContainer,
 } from "recharts";
+import type { BarShapeProps } from "recharts";
 import { Header, Footer, TooltipOnHover } from "../../src/components";
 import { useChartTooltipProps } from "../../src/utils/ThemeContext";
-import { formatCurrency, formatPercent, formatStateValue } from "../../src/utils";
+import {
+  formatCurrency,
+  formatPercent,
+  formatStateValue,
+} from "../../src/utils";
 import {
   calcDcaVsLumpSum,
   type DcaInputs,
@@ -128,12 +134,10 @@ export default function DcaVsLumpSum() {
   // Price path data (normalised to 100)
   const pricePath = useMemo(() => {
     let price = 100;
-    return result.monthlyReturns
-      .slice(0, horizonMonths)
-      .map((r, i) => {
-        price = price * (1 + r);
-        return { month: i + 1, price };
-      });
+    return result.monthlyReturns.slice(0, horizonMonths).map((r, i) => {
+      price = price * (1 + r);
+      return { month: i + 1, price };
+    });
   }, [result.monthlyReturns, horizonMonths]);
 
   // Final value bar chart data
@@ -211,7 +215,10 @@ export default function DcaVsLumpSum() {
           <div className={styles.dcaSlider}>
             <div className={styles.dcaMonthDisplay}>
               <Form.Label className="mb-0">Spread investments over</Form.Label>
-              <span className={styles.dcaMonthBadge} style={{ color: DCA_COLOR }}>
+              <span
+                className={styles.dcaMonthBadge}
+                style={{ color: DCA_COLOR }}
+              >
                 {inputs.dcaMonths}
               </span>
               <Form.Label className="mb-0">months</Form.Label>
@@ -233,8 +240,8 @@ export default function DcaVsLumpSum() {
           <p className={shared.rateHint}>
             Monthly installment:{" "}
             <strong>{formatCurrency(result.monthlyInstallment)}</strong> — cash
-            not yet invested earns {formatPercent(inputs.savingsAccountRate)}{" "}
-            in a HYSA
+            not yet invested earns {formatPercent(inputs.savingsAccountRate)} in
+            a HYSA
           </p>
 
           {/* ── Return Assumptions ── */}
@@ -301,28 +308,28 @@ export default function DcaVsLumpSum() {
           <div className={styles.scenarioGrid}>
             {SCENARIOS.map((s) => (
               <div key={s.value}>
-              <TooltipOnHover
-                text={s.description}
-                nest={
-                  <div
-                    className={
-                      inputs.scenario === s.value
-                        ? styles.scenarioCardActive
-                        : styles.scenarioCard
-                    }
-                    onClick={() => setField("scenario", s.value)}
-                    role="button"
-                    tabIndex={0}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ")
-                        setField("scenario", s.value);
-                    }}
-                  >
-                    <div className={styles.scenarioIcon}>{s.icon}</div>
-                    <div>{s.label}</div>
-                  </div>
-                }
-              />
+                <TooltipOnHover
+                  text={s.description}
+                  nest={
+                    <div
+                      className={
+                        inputs.scenario === s.value
+                          ? styles.scenarioCardActive
+                          : styles.scenarioCard
+                      }
+                      onClick={() => setField("scenario", s.value)}
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ")
+                          setField("scenario", s.value);
+                      }}
+                    >
+                      <div className={styles.scenarioIcon}>{s.icon}</div>
+                      <div>{s.label}</div>
+                    </div>
+                  }
+                />
               </div>
             ))}
           </div>
@@ -341,14 +348,18 @@ export default function DcaVsLumpSum() {
             {dcaWins ? (
               <>
                 DCA ends up{" "}
-                <strong>{formatCurrency(Math.abs(result.dcaVsLumpSumDiff))}</strong>{" "}
+                <strong>
+                  {formatCurrency(Math.abs(result.dcaVsLumpSumDiff))}
+                </strong>{" "}
                 ahead. The HYSA interest on uninvested cash and lower average
                 buy price more than compensate for time out of market.
               </>
             ) : (
               <>
                 Lump Sum ends up{" "}
-                <strong>{formatCurrency(Math.abs(result.dcaVsLumpSumDiff))}</strong>{" "}
+                <strong>
+                  {formatCurrency(Math.abs(result.dcaVsLumpSumDiff))}
+                </strong>{" "}
                 ahead. Getting fully invested immediately lets compounding work
                 on the full amount sooner.
               </>
@@ -378,10 +389,7 @@ export default function DcaVsLumpSum() {
               <div className={shared.cardLabel}>
                 {dcaWins ? "DCA Advantage" : "Lump Sum Advantage"}
               </div>
-              <div
-                className={shared.cardValue}
-                style={{ color: winnerColor }}
-              >
+              <div className={shared.cardValue} style={{ color: winnerColor }}>
                 {formatCurrency(Math.abs(result.dcaVsLumpSumDiff))}
               </div>
               <div className={shared.cardSub}>
@@ -444,7 +452,10 @@ export default function DcaVsLumpSum() {
           {chartView === "growth" && (
             <div className={shared.chartWrap}>
               <h5 className="text-center mb-1">Portfolio Value Over Time</h5>
-              <p className="text-center text-muted mb-3" style={{ fontSize: "0.82rem" }}>
+              <p
+                className="text-center text-muted mb-3"
+                style={{ fontSize: "0.82rem" }}
+              >
                 DCA total includes cash still in HYSA
               </p>
               <ResponsiveContainer width="100%" height={380}>
@@ -464,11 +475,13 @@ export default function DcaVsLumpSum() {
                   />
                   <YAxis tickFormatter={formatChartDollar} width={65} />
                   <Tooltip
-                    formatter={(value: number | undefined, name: string | undefined) => [
-                      formatCurrency(value ?? 0),
-                      name ?? "",
-                    ]}
-                    labelFormatter={(m) => `Month ${m} (${formatMonth(m as number)})`}
+                    formatter={(
+                      value: number | undefined,
+                      name: string | undefined,
+                    ) => [formatCurrency(value ?? 0), name ?? ""]}
+                    labelFormatter={(m) =>
+                      `Month ${m} (${formatMonth(m as number)})`
+                    }
                     contentStyle={tooltipStyle}
                     labelStyle={tooltipLabelStyle}
                   />
@@ -537,10 +550,10 @@ export default function DcaVsLumpSum() {
                   <XAxis dataKey="name" />
                   <YAxis tickFormatter={formatChartDollar} width={65} />
                   <Tooltip
-                    formatter={(value: number | undefined, name: string | undefined) => [
-                      formatCurrency(value ?? 0),
-                      name ?? "",
-                    ]}
+                    formatter={(
+                      value: number | undefined,
+                      name: string | undefined,
+                    ) => [formatCurrency(value ?? 0), name ?? ""]}
                     contentStyle={tooltipStyle}
                     labelStyle={tooltipLabelStyle}
                   />
@@ -548,27 +561,14 @@ export default function DcaVsLumpSum() {
                     dataKey="value"
                     name="Final Value"
                     isAnimationActive={false}
-                    shape={(props: Record<string, unknown>) => {
-                      const { x, y, width, height, index } = props as {
-                        x: number;
-                        y: number;
-                        width: number;
-                        height: number;
-                        index: number;
-                      };
-                      return (
-                        <rect
-                          x={x}
-                          y={y}
-                          width={width}
-                          height={height}
-                          fill={barData[index]?.fill ?? "#888"}
-                          opacity={0.85}
-                          rx={4}
-                          ry={4}
-                        />
-                      );
-                    }}
+                    shape={(props: BarShapeProps) => (
+                      <Rectangle
+                        {...props}
+                        fill={barData[props.index]?.fill ?? "#888"}
+                        fillOpacity={0.85}
+                        radius={4}
+                      />
+                    )}
                   />
                 </BarChart>
               </ResponsiveContainer>
@@ -659,7 +659,9 @@ export default function DcaVsLumpSum() {
                       (v ?? 0).toFixed(1),
                       "Price index",
                     ]}
-                    labelFormatter={(m) => `Month ${m} (${formatMonth(m as number)})`}
+                    labelFormatter={(m) =>
+                      `Month ${m} (${formatMonth(m as number)})`
+                    }
                     contentStyle={tooltipStyle}
                     labelStyle={tooltipLabelStyle}
                   />
@@ -667,7 +669,11 @@ export default function DcaVsLumpSum() {
                     y={100}
                     stroke="#888"
                     strokeDasharray="4 3"
-                    label={{ value: "Start", position: "insideTopLeft", fontSize: 11 }}
+                    label={{
+                      value: "Start",
+                      position: "insideTopLeft",
+                      fontSize: 11,
+                    }}
                   />
                   {inputs.dcaMonths > 1 && (
                     <ReferenceLine

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -45,6 +45,10 @@ const NAV_ENTRIES: NavEntry[] = [
         href: "/learn/money-flow",
         label: "Where to Put My Money",
       },
+      {
+        href: "/learn/dca-vs-lump-sum",
+        label: "DCA vs Lump Sum",
+      },
     ],
   },
   {
@@ -72,6 +76,7 @@ const PAGE_NAMES: Record<string, string> = {
   "/learn/tax-rates": "How Federal Tax Works",
   "/learn/capital-gains": "Capital Gains & Qualified Dividends",
   "/learn/money-flow": "Where to Put My Money",
+  "/learn/dca-vs-lump-sum": "DCA vs Lump Sum",
   "/retirement/savings-optimizer": "401k Optimizer",
   "/retirement/maximize": "401k Maximize",
   "/retirement/income": "Retirement Income",

--- a/src/utils/dca_vs_lumpsum_utils.ts
+++ b/src/utils/dca_vs_lumpsum_utils.ts
@@ -6,7 +6,7 @@
  * earning interest. Supports bullish, bearish, and volatile market scenarios.
  */
 
-export type MarketScenario = "bull" | "bear" | "volatile" | "flat" | "custom";
+export type MarketScenario = "bull" | "bear" | "volatile" | "flat";
 
 export interface DcaInputs {
   totalAmount: number; // total money available to invest
@@ -15,7 +15,7 @@ export interface DcaInputs {
   marketReturnRate: number; // nominal annual market return (e.g. 0.10)
   savingsAccountRate: number; // HYSA annual rate for uninvested cash
   scenario: MarketScenario;
-  customMonthlyReturns: number[]; // used when scenario === "custom"
+  scenarioIntensity: number; // 0–1: how extreme the scenario path is (0 = flat, 1 = max)
 }
 
 export interface MonthlyDataPoint {
@@ -42,86 +42,76 @@ export interface DcaResult {
   monthlyReturns: number[]; // actual monthly return rates used
 }
 
-/** Build a sequence of monthly returns for a given scenario over N months. */
-function buildMonthlyReturns(
-  inputs: DcaInputs,
-  totalMonths: number,
-): number[] {
-  const { scenario, marketReturnRate, customMonthlyReturns } = inputs;
-  const monthlyBase = Math.pow(1 + marketReturnRate, 1 / 12) - 1;
+/**
+ * Build a sequence of monthly returns for a given scenario over N months.
+ *
+ * All non-flat scenarios keep the arithmetic mean of their multipliers at 1.0,
+ * so the long-run average return stays close to `marketReturnRate`.
+ * `scenarioIntensity` (0–1) scales how far returns deviate from the flat case:
+ *   0 = perfectly flat, 1 = maximum path effect.
+ *
+ * Amplitude constants chosen so intensity=1.0 produces realistic extremes:
+ *   bull:     ±1× of base (0× at start → 2× at end)
+ *   bear:     ±4× of base (sharp dip then sharp recovery — ~25% annualised drop at peak)
+ *   volatile: ±3× of base (~17% annualised down to ~46% annualised up, alternating)
+ */
+function buildMonthlyReturns(inputs: DcaInputs, totalMonths: number): number[] {
+  const { scenario, marketReturnRate, scenarioIntensity } = inputs;
+  const I = scenarioIntensity;
+  const mb = Math.pow(1 + marketReturnRate, 1 / 12) - 1;
 
   switch (scenario) {
     case "bull": {
-      // Gradually accelerating — starts below average, ends above
+      // Ramp from (1 - I)× to (1 + I)× — arithmetic mean of multipliers = 1 ✓
       return Array.from({ length: totalMonths }, (_, i) => {
         const t = i / Math.max(totalMonths - 1, 1);
-        // ramp from 0.4× to 1.8× of the average monthly return
-        return monthlyBase * (0.4 + 1.4 * t);
+        return mb * (1 + I * (2 * t - 1));
       });
     }
     case "bear": {
-      // Market drops in the first half, recovers in the second half
+      // Cosine V-shape: drops then recovers.
+      // ∫cos(πt) dt from 0→1 = 0, so arithmetic mean of multipliers = 1 ✓
       return Array.from({ length: totalMonths }, (_, i) => {
         const t = i / Math.max(totalMonths - 1, 1);
-        // V-shape: down then up
-        const phase = Math.cos(Math.PI * t); // 1 at start, -1 at mid, 1 at end
-        return monthlyBase * (1 - 1.5 * phase);
+        return mb * (1 - I * 4 * Math.cos(Math.PI * t));
       });
     }
     case "volatile": {
-      // Alternating up/down with same long-run average
+      // Alternating up/down months — mean = 1 ✓ (with an even number of months)
       return Array.from({ length: totalMonths }, (_, i) => {
         const sign = i % 2 === 0 ? 1 : -1;
-        // Swing ±2× around the base, but keep same annualized return geometrically
-        return monthlyBase + sign * monthlyBase * 1.5;
+        return mb * (1 + sign * I * 3);
       });
     }
-    case "flat": {
-      return Array.from({ length: totalMonths }, () => monthlyBase);
-    }
-    case "custom": {
-      // Repeat provided values cyclically
-      if (customMonthlyReturns.length === 0)
-        return Array.from({ length: totalMonths }, () => monthlyBase);
-      return Array.from(
-        { length: totalMonths },
-        (_, i) => customMonthlyReturns[i % customMonthlyReturns.length],
-      );
-    }
+    case "flat":
     default:
-      return Array.from({ length: totalMonths }, () => monthlyBase);
+      return Array.from({ length: totalMonths }, () => mb);
   }
 }
 
 const SCENARIO_LABELS: Record<MarketScenario, string> = {
   bull: "Bull Market (steady climb)",
-  bear: "Bear Market (dip then recovery)",
+  bear: "Bear then Bull (V-shape)",
   volatile: "Volatile (alternating swings)",
   flat: "Flat / Average",
-  custom: "Custom",
 };
 
 export function calcDcaVsLumpSum(inputs: DcaInputs): DcaResult {
-  const {
-    totalAmount,
-    investmentHorizonYears,
-    dcaMonths,
-    savingsAccountRate,
-  } = inputs;
+  const { totalAmount, investmentHorizonYears, dcaMonths, savingsAccountRate } =
+    inputs;
 
   const totalMonths = Math.max(investmentHorizonYears * 12, dcaMonths);
   const monthlyInstallment = totalAmount / Math.max(dcaMonths, 1);
   const monthlySavingsRate = Math.pow(1 + savingsAccountRate, 1 / 12) - 1;
   const monthlyReturns = buildMonthlyReturns(inputs, totalMonths);
 
-  // Track price index for average cost calculation
+  // Track price index for average-cost calculation
   let priceIndex = 100; // starts at 100
   const dcaBuyPrices: { amount: number; price: number }[] = [];
 
   let dcaPortfolio = 0;
   let dcaCash = totalAmount; // all money starts in HYSA
   let lumpSumPortfolio = totalAmount; // lump sum invests everything immediately
-  let dcaSharesEquivalent = 0; // track shares * initial price for avg cost
 
   const monthlyData: MonthlyDataPoint[] = [];
 
@@ -144,13 +134,13 @@ export function calcDcaVsLumpSum(inputs: DcaInputs): DcaResult {
     dcaPortfolio = dcaPortfolio * (1 + monthlyReturn);
     lumpSumPortfolio = lumpSumPortfolio * (1 + monthlyReturn);
 
-    // Update price index (tracks cumulative market price)
+    // Update price index (cumulative market level)
     priceIndex = priceIndex * (1 + monthlyReturn);
 
     // DCA: apply HYSA interest to uninvested cash
     dcaCash = dcaCash * (1 + monthlySavingsRate);
 
-    // DCA: invest this month's installment (if still in DCA period)
+    // DCA: deploy this month's installment (if still in DCA period)
     if (m <= dcaMonths) {
       const installment = Math.min(monthlyInstallment, dcaCash);
       dcaCash -= installment;
@@ -171,11 +161,14 @@ export function calcDcaVsLumpSum(inputs: DcaInputs): DcaResult {
     });
   }
 
-  // Calculate weighted average buy price for DCA
+  // Weighted average buy price for DCA
   const totalInvested = dcaBuyPrices.reduce((s, p) => s + p.amount, 0);
   const weightedPrice =
     totalInvested > 0
-      ? dcaBuyPrices.reduce((s, p) => s + (p.amount / totalInvested) * p.price, 0)
+      ? dcaBuyPrices.reduce(
+          (s, p) => s + (p.amount / totalInvested) * p.price,
+          0,
+        )
       : lumpSumBuyPrice;
 
   const finalDcaTotal = dcaPortfolio + dcaCash;

--- a/src/utils/dca_vs_lumpsum_utils.ts
+++ b/src/utils/dca_vs_lumpsum_utils.ts
@@ -1,0 +1,198 @@
+/**
+ * DCA vs Lump Sum — investment strategy comparison
+ *
+ * Compares dollar-cost averaging (investing periodically) against investing a
+ * lump sum immediately. Money not yet invested sits in a savings account (HYSA)
+ * earning interest. Supports bullish, bearish, and volatile market scenarios.
+ */
+
+export type MarketScenario = "bull" | "bear" | "volatile" | "flat" | "custom";
+
+export interface DcaInputs {
+  totalAmount: number; // total money available to invest
+  investmentHorizonYears: number; // how many years until we care about the final value
+  dcaMonths: number; // how many months to spread DCA over (1 = lump sum equivalent)
+  marketReturnRate: number; // nominal annual market return (e.g. 0.10)
+  savingsAccountRate: number; // HYSA annual rate for uninvested cash
+  scenario: MarketScenario;
+  customMonthlyReturns: number[]; // used when scenario === "custom"
+}
+
+export interface MonthlyDataPoint {
+  month: number;
+  dcaPortfolio: number; // invested balance for DCA
+  dcaCash: number; // cash still in HYSA for DCA
+  dcaTotal: number; // dcaPortfolio + dcaCash
+  lumpSumPortfolio: number; // invested balance for lump sum
+  invested: number; // cumulative amount invested in DCA so far
+}
+
+export interface DcaResult {
+  monthlyData: MonthlyDataPoint[];
+  finalDcaTotal: number;
+  finalLumpSum: number;
+  dcaVsLumpSumDiff: number; // finalDcaTotal - finalLumpSum (+ve = DCA wins)
+  dcaWins: boolean;
+  totalContributed: number;
+  monthlyInstallment: number;
+  averageBuyPrice: number; // weighted avg price index for DCA
+  lumpSumBuyPrice: number; // price index at month 0
+  avgCostAdvantage: number; // lumpSumBuyPrice - averageBuyPrice (+ = DCA got cheaper avg)
+  scenarioLabel: string;
+  monthlyReturns: number[]; // actual monthly return rates used
+}
+
+/** Build a sequence of monthly returns for a given scenario over N months. */
+function buildMonthlyReturns(
+  inputs: DcaInputs,
+  totalMonths: number,
+): number[] {
+  const { scenario, marketReturnRate, customMonthlyReturns } = inputs;
+  const monthlyBase = Math.pow(1 + marketReturnRate, 1 / 12) - 1;
+
+  switch (scenario) {
+    case "bull": {
+      // Gradually accelerating — starts below average, ends above
+      return Array.from({ length: totalMonths }, (_, i) => {
+        const t = i / Math.max(totalMonths - 1, 1);
+        // ramp from 0.4× to 1.8× of the average monthly return
+        return monthlyBase * (0.4 + 1.4 * t);
+      });
+    }
+    case "bear": {
+      // Market drops in the first half, recovers in the second half
+      return Array.from({ length: totalMonths }, (_, i) => {
+        const t = i / Math.max(totalMonths - 1, 1);
+        // V-shape: down then up
+        const phase = Math.cos(Math.PI * t); // 1 at start, -1 at mid, 1 at end
+        return monthlyBase * (1 - 1.5 * phase);
+      });
+    }
+    case "volatile": {
+      // Alternating up/down with same long-run average
+      return Array.from({ length: totalMonths }, (_, i) => {
+        const sign = i % 2 === 0 ? 1 : -1;
+        // Swing ±2× around the base, but keep same annualized return geometrically
+        return monthlyBase + sign * monthlyBase * 1.5;
+      });
+    }
+    case "flat": {
+      return Array.from({ length: totalMonths }, () => monthlyBase);
+    }
+    case "custom": {
+      // Repeat provided values cyclically
+      if (customMonthlyReturns.length === 0)
+        return Array.from({ length: totalMonths }, () => monthlyBase);
+      return Array.from(
+        { length: totalMonths },
+        (_, i) => customMonthlyReturns[i % customMonthlyReturns.length],
+      );
+    }
+    default:
+      return Array.from({ length: totalMonths }, () => monthlyBase);
+  }
+}
+
+const SCENARIO_LABELS: Record<MarketScenario, string> = {
+  bull: "Bull Market (steady climb)",
+  bear: "Bear Market (dip then recovery)",
+  volatile: "Volatile (alternating swings)",
+  flat: "Flat / Average",
+  custom: "Custom",
+};
+
+export function calcDcaVsLumpSum(inputs: DcaInputs): DcaResult {
+  const {
+    totalAmount,
+    investmentHorizonYears,
+    dcaMonths,
+    savingsAccountRate,
+  } = inputs;
+
+  const totalMonths = Math.max(investmentHorizonYears * 12, dcaMonths);
+  const monthlyInstallment = totalAmount / Math.max(dcaMonths, 1);
+  const monthlySavingsRate = Math.pow(1 + savingsAccountRate, 1 / 12) - 1;
+  const monthlyReturns = buildMonthlyReturns(inputs, totalMonths);
+
+  // Track price index for average cost calculation
+  let priceIndex = 100; // starts at 100
+  const dcaBuyPrices: { amount: number; price: number }[] = [];
+
+  let dcaPortfolio = 0;
+  let dcaCash = totalAmount; // all money starts in HYSA
+  let lumpSumPortfolio = totalAmount; // lump sum invests everything immediately
+  let dcaSharesEquivalent = 0; // track shares * initial price for avg cost
+
+  const monthlyData: MonthlyDataPoint[] = [];
+
+  // Record initial state (month 0)
+  monthlyData.push({
+    month: 0,
+    dcaPortfolio: 0,
+    dcaCash: totalAmount,
+    dcaTotal: totalAmount,
+    lumpSumPortfolio: totalAmount,
+    invested: 0,
+  });
+
+  const lumpSumBuyPrice = priceIndex;
+
+  for (let m = 1; m <= totalMonths; m++) {
+    const monthlyReturn = monthlyReturns[m - 1] ?? 0;
+
+    // Apply market return to both portfolios
+    dcaPortfolio = dcaPortfolio * (1 + monthlyReturn);
+    lumpSumPortfolio = lumpSumPortfolio * (1 + monthlyReturn);
+
+    // Update price index (tracks cumulative market price)
+    priceIndex = priceIndex * (1 + monthlyReturn);
+
+    // DCA: apply HYSA interest to uninvested cash
+    dcaCash = dcaCash * (1 + monthlySavingsRate);
+
+    // DCA: invest this month's installment (if still in DCA period)
+    if (m <= dcaMonths) {
+      const installment = Math.min(monthlyInstallment, dcaCash);
+      dcaCash -= installment;
+      dcaPortfolio += installment;
+      dcaBuyPrices.push({ amount: installment, price: priceIndex });
+    }
+
+    const dcaTotal = dcaPortfolio + dcaCash;
+    const invested = Math.min(m * monthlyInstallment, totalAmount);
+
+    monthlyData.push({
+      month: m,
+      dcaPortfolio,
+      dcaCash,
+      dcaTotal,
+      lumpSumPortfolio,
+      invested,
+    });
+  }
+
+  // Calculate weighted average buy price for DCA
+  const totalInvested = dcaBuyPrices.reduce((s, p) => s + p.amount, 0);
+  const weightedPrice =
+    totalInvested > 0
+      ? dcaBuyPrices.reduce((s, p) => s + (p.amount / totalInvested) * p.price, 0)
+      : lumpSumBuyPrice;
+
+  const finalDcaTotal = dcaPortfolio + dcaCash;
+  const finalLumpSum = lumpSumPortfolio;
+
+  return {
+    monthlyData,
+    finalDcaTotal,
+    finalLumpSum,
+    dcaVsLumpSumDiff: finalDcaTotal - finalLumpSum,
+    dcaWins: finalDcaTotal >= finalLumpSum,
+    totalContributed: totalAmount,
+    monthlyInstallment,
+    averageBuyPrice: weightedPrice,
+    lumpSumBuyPrice,
+    avgCostAdvantage: lumpSumBuyPrice - weightedPrice,
+    scenarioLabel: SCENARIO_LABELS[inputs.scenario],
+    monthlyReturns,
+  };
+}

--- a/styles/DcaVsLumpSum.module.scss
+++ b/styles/DcaVsLumpSum.module.scss
@@ -1,0 +1,81 @@
+@use "breakpoints" as *;
+
+.scenarioGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+  margin-bottom: 1rem;
+
+  @media screen and (min-width: $medium) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.scenarioCard {
+  border: 2px solid var(--bs-border-color);
+  border-radius: 8px;
+  padding: 10px 12px;
+  cursor: pointer;
+  text-align: center;
+  transition: border-color 0.15s, background 0.15s;
+  font-size: 0.82rem;
+  background: var(--bs-secondary-bg);
+
+  &:hover {
+    border-color: var(--bs-primary);
+  }
+}
+
+.scenarioCardActive {
+  composes: scenarioCard;
+  border-color: var(--bs-primary);
+  background: var(--bs-primary-bg-subtle, var(--bs-primary));
+  color: var(--bs-primary-text-emphasis, #fff);
+}
+
+.scenarioIcon {
+  font-size: 1.4rem;
+  margin-bottom: 4px;
+}
+
+.winnerBadge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 2px 7px;
+  border-radius: 10px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+.winnerBadgeDca {
+  composes: winnerBadge;
+  background: #2980b9;
+  color: #fff;
+}
+
+.winnerBadgeLump {
+  composes: winnerBadge;
+  background: #8e44ad;
+  color: #fff;
+}
+
+.dcaSlider {
+  margin-bottom: 1.25rem;
+}
+
+.dcaMonthDisplay {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.dcaMonthBadge {
+  font-size: 1.4rem;
+  font-weight: 700;
+  min-width: 2.5rem;
+  text-align: center;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -15,6 +19,12 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Interactive calculator comparing dollar-cost averaging against lump sum investing. Users can tune total amount, investment horizon, DCA spread period, market/HYSA rates, and pick from four market scenarios (bull, bear, volatile, flat). Uninvested DCA cash earns HYSA interest. Includes three chart views: portfolio growth over time, final value comparison table, and market price path.

https://claude.ai/code/session_01RoYLk8uTyY8rUyk993KPZf